### PR TITLE
[fix] always cleanup containers in pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,5 +38,7 @@ node('aam-identity-prodcd') {
         junit 'results.xml'
         error 'Thunderstorm Client Staging build failed ${err}'
 
+    } finally {
+        sh 'docker-compose down'
     }
 }


### PR DESCRIPTION
This ensures the build's containers are shutdown even if the pipeline fails hard.