### PR TITLE
Add group mapping model factory and sync task.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-pyjwt>=1.5.2,<2
 cryptography>=2.0.3,<3
+celery>=4.0,<4.2
+pyjwt>=1.5.2,<2
+sqlalchemy>=1.1,<1.2

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -1,13 +1,6 @@
-import kombu.common
 from sqlalchemy.ext.declarative import declarative_base
 
 from thunderstorm_auth import group
-
-
-def test_complex_group_type_queue():
-    queue = group.COMPLEX_GROUP_TYPE.queue
-    assert isinstance(queue, kombu.common.Broadcast)
-    assert queue.alias == 'thunderstorm_auth.group.sync.complex'
 
 
 def test_create_complex_group_model():

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -3,6 +3,20 @@ from sqlalchemy.ext.declarative import declarative_base
 from thunderstorm_auth import group
 
 
+def test_group_type_attributes():
+    # act
+    example_type = group.GroupType('example')
+    queue_name = example_type.queue_name('my_service')
+
+    # assert
+    assert example_type.table_name == 'example_group_association'
+    assert example_type.model_name == 'ExampleGroupAssociation'
+    assert example_type.member_column_name == 'example_uuid'
+    assert example_type.task_name == 'ts_auth.group.example.sync'
+    assert example_type.routing_key == 'group.example'
+    assert queue_name == 'my_service.ts_auth.group.example'
+
+
 def test_create_complex_group_model():
     # arrange
     base = declarative_base()

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -1,0 +1,28 @@
+import kombu.common
+from sqlalchemy.ext.declarative import declarative_base
+
+from thunderstorm_auth import group
+
+
+def test_complex_group_type_queue():
+    queue = group.COMPLEX_GROUP_TYPE.queue
+    assert isinstance(queue, kombu.common.Broadcast)
+    assert queue.alias == 'thunderstorm_auth.group.sync.complex'
+
+
+def test_create_complex_group_model():
+    # arrange
+    base = declarative_base()
+
+    # act
+    model = group.create_group_map_model(
+        group.COMPLEX_GROUP_TYPE, base
+    )
+
+    # assert
+    assert model.__name__ == 'ComplexGroupMap'
+    assert model.__tablename__ == 'complex_group_map'
+    assert model.__ts_group_type__ == group.COMPLEX_GROUP_TYPE
+    assert issubclass(model, base)
+    assert hasattr(model, 'group_uuid')
+    assert hasattr(model, 'complex_uuid')

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -8,13 +8,13 @@ def test_create_complex_group_model():
     base = declarative_base()
 
     # act
-    model = group.create_group_map_model(
+    model = group.create_group_association_model(
         group.COMPLEX_GROUP_TYPE, base
     )
 
     # assert
-    assert model.__name__ == 'ComplexGroupMap'
-    assert model.__tablename__ == 'complex_group_map'
+    assert model.__name__ == 'ComplexGroupAssociation'
+    assert model.__tablename__ == 'complex_group_association'
     assert model.__ts_group_type__ == group.COMPLEX_GROUP_TYPE
     assert issubclass(model, base)
     assert hasattr(model, 'group_uuid')

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -20,8 +20,8 @@ def models(group_types):
     base = declarative_base()
     foo_type, bar_type = group_types
     return [
-        group.create_group_map_model(foo_type, base),
-        group.create_group_map_model(bar_type, base)
+        group.create_group_association_model(foo_type, base),
+        group.create_group_association_model(bar_type, base)
     ]
 
 

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+import celery
+import pytest
+from sqlalchemy.ext.declarative import declarative_base
+
+from thunderstorm_auth import group, setup
+
+
+@pytest.fixture
+def group_types():
+    return [
+        group.GroupType('foo'),
+        group.GroupType('bar')
+    ]
+
+
+@pytest.fixture
+def models(group_types):
+    base = declarative_base()
+    foo_type, bar_type = group_types
+    return [
+        group.create_group_map_model(foo_type, base),
+        group.create_group_map_model(bar_type, base)
+    ]
+
+
+@pytest.fixture
+def celery_app(group_types):
+    foo_type, bar_type = group_types
+    app = celery.Celery()
+    yield app
+    app.tasks.unregister(foo_type.task_name)
+    app.tasks.unregister(bar_type.task_name)
+
+
+def test_init_group_sync_tasks(celery_app, models, group_types):
+    # arrange
+    foo_type, bar_type = group_types
+    db_session = mock.Mock()
+
+    # act
+    setup.init_group_sync_tasks(celery_app, db_session, models)
+
+    # assert
+    assert celery_app.conf.task_queues == [
+        foo_type.queue,
+        bar_type.queue
+    ]
+    assert foo_type.task_name in celery_app.tasks
+    assert bar_type.task_name in celery_app.tasks

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -43,9 +43,8 @@ def test_init_group_sync_tasks(celery_app, models, group_types):
     setup.init_group_sync_tasks(celery_app, db_session, models)
 
     # assert
-    assert {q.alias for q in celery_app.conf.task_queues} == {
-        foo_type.task_name,
-        bar_type.task_name
-    }
+    queue_names = {q.name for q in celery_app.conf.task_queues}
+    assert foo_type.queue_name(celery_app.main) in queue_names
+    assert bar_type.queue_name(celery_app.main) in queue_names
     assert foo_type.task_name in celery_app.tasks
     assert bar_type.task_name in celery_app.tasks

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -43,9 +43,9 @@ def test_init_group_sync_tasks(celery_app, models, group_types):
     setup.init_group_sync_tasks(celery_app, db_session, models)
 
     # assert
-    assert celery_app.conf.task_queues == [
-        foo_type.queue,
-        bar_type.queue
-    ]
+    assert {q.alias for q in celery_app.conf.task_queues} == {
+        foo_type.task_name,
+        bar_type.task_name
+    }
     assert foo_type.task_name in celery_app.tasks
     assert bar_type.task_name in celery_app.tasks

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -29,6 +29,10 @@ def _teardown_celery_app(group_type):
         app.tasks.unregister(group_type.task_name)
 
 
+def test_exchange_name():
+    assert tasks.EXCHANGE.name == 'ts_auth.group'
+
+
 def test_create_group_sync_queue(group_type):
     # arrange
     celery_app = celery.Celery('test_app')
@@ -37,10 +41,10 @@ def test_create_group_sync_queue(group_type):
     queue = tasks.group_sync_queue(group_type, celery_app.main)
 
     # assert
-    assert isinstance(queue, kombu.common.Broadcast)
-    assert queue.alias == 'thunderstorm_auth.example_group.sync'
-    assert queue.name == 'thunderstorm_auth.example_group.sync.bcast.test_app'
-    assert queue.exchange.name == 'thunderstorm_auth.example_group.sync'
+    assert isinstance(queue, kombu.Queue)
+    assert queue.name == 'test_app.ts_auth.group.example'
+    assert queue.exchange == tasks.EXCHANGE
+    assert queue.routing_key == 'group.example'
 
 
 def test_create_group_sync_task(model):
@@ -52,7 +56,7 @@ def test_create_group_sync_task(model):
 
     # assert
     assert isinstance(task, celery.task.Task)
-    assert task.name == 'thunderstorm_auth.example_group.sync'
+    assert task.name == 'ts_auth.group.example.sync'
 
 
 @mock.patch('thunderstorm_auth.tasks.get_current_members')

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -1,0 +1,77 @@
+import uuid
+
+import celery
+import celery.task
+import pytest
+from sqlalchemy.ext.declarative import declarative_base
+from unittest import mock
+
+from thunderstorm_auth import group, tasks
+
+
+@pytest.fixture
+def group_type():
+    return group.GroupType('example')
+
+
+@pytest.fixture
+def model(group_type):
+    base = declarative_base()
+    return group.create_group_map_model(group_type, base)
+
+
+@pytest.fixture(autouse=True)
+def celery_app(group_type):
+    app = celery.current_app
+    yield
+    app.tasks.unregister(group_type.task_name)
+
+
+def test_create_group_sync_task(model):
+    # arrange
+    db_session = mock.Mock()
+
+    # act
+    task = tasks.group_sync_task(model, db_session)
+
+    # assert
+    assert isinstance(task, celery.task.Task)
+    assert task.name == 'thunderstorm_auth.group.sync.example'
+
+
+@mock.patch('thunderstorm_auth.tasks.get_current_members')
+@mock.patch('thunderstorm_auth.tasks.delete_group_maps')
+@mock.patch('thunderstorm_auth.tasks.add_group_maps')
+def test_group_sync_task_run(
+        add_group_maps, delete_group_maps, get_current_members, model):
+    # arrange
+    db_session = mock.Mock(name='db_session')
+    task = tasks.group_sync_task(model, db_session)
+
+    group_uuid = uuid.uuid4()
+    all_members = [uuid.uuid4() for _ in range(4)]
+
+    get_current_members.return_value = set(all_members[:3])  # currently 0, 1, 2
+    updated_members = all_members[1:]  # updated to 1, 2, 3
+
+    # act
+    task(group_uuid, updated_members)
+
+    # assert
+    get_current_members.assert_called_with(
+        db_session,
+        model,
+        group_uuid
+    )
+    delete_group_maps.assert_called_with(
+        db_session,
+        model,
+        group_uuid,
+        {all_members[0]}
+    )
+    add_group_maps.assert_called_with(
+        db_session,
+        model,
+        group_uuid,
+        {all_members[3]}
+    )

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.0.6'
+__version__ = '0.0.7'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.0.7'
+__version__ = '0.1.0'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'

--- a/thunderstorm_auth/group.py
+++ b/thunderstorm_auth/group.py
@@ -1,0 +1,58 @@
+import kombu.common
+from sqlalchemy import Column
+from sqlalchemy.dialects.postgresql import UUID
+
+
+SCHEMA = 'ts_auth'
+
+
+def _camel_case(value):
+    return ''.join(part.capitalize() for part in value.split('_'))
+
+
+class GroupType:
+    """Definition of a auth group type.
+
+    Provides sync task name, task queue and model/table names.
+    """
+
+    _table_name_tmpl = '{}_group_map'
+    _map_column_name_tmpl = '{}_uuid'
+    _task_name_tmpl = 'thunderstorm_auth.group.sync.{}'
+
+    def __init__(self, name):
+        self.name = name.lower()
+        self.table_name = self._table_name_tmpl.format(self.name)
+        self.model_name = _camel_case(self.table_name)
+        self.map_column_name = self._map_column_name_tmpl.format(self.name)
+
+        self.task_name = self._task_name_tmpl.format(self.name)
+
+        self.queue = kombu.common.Broadcast(self.task_name)
+
+
+COMPLEX_GROUP_TYPE = GroupType('complex')
+
+
+def create_group_map_model(group_type, base):
+    """
+    Create a SQLAlchemy model representing the mapping of data to groups.
+
+    Args:
+        group_type (GroupType): Type of group model to create.
+        base (Base): Declarative base of database schema to add model to.
+
+    Returns:
+        SQLALchemy model of group mapping. Depending on `group_type`.
+    """
+    return type(
+        group_type.model_name,
+        (base,),
+        {
+            '__ts_group_type__': group_type,
+            '__tablename__': group_type.table_name,
+            '__table_args__ ': {'schema': SCHEMA},
+            'group_uuid': Column(UUID(as_uuid=True), primary_key=True),
+            group_type.map_column_name: Column(UUID(as_uuid=True), primary_key=True)
+        }
+    )

--- a/thunderstorm_auth/group.py
+++ b/thunderstorm_auth/group.py
@@ -12,18 +12,18 @@ def _camel_case(value):
 class GroupType:
     """Definition of a auth group type.
 
-    Provides sync task name, model name, table names, mapping column name.
+    Provides sync task name, model name, table names, member column name.
     """
 
-    _table_name_tmpl = '{}_group_map'
-    _map_column_name_tmpl = '{}_uuid'
-    _task_name_tmpl = 'thunderstorm_auth.group.sync.{}'
+    _table_name_tmpl = '{}_group_association'
+    _member_column_name_tmpl = '{}_uuid'
+    _task_name_tmpl = 'thunderstorm_auth.{}_group.sync'
 
     def __init__(self, name):
         self.name = name.lower()
         self.table_name = self._table_name_tmpl.format(self.name)
         self.model_name = _camel_case(self.table_name)
-        self.map_column_name = self._map_column_name_tmpl.format(self.name)
+        self.member_column_name = self._member_column_name_tmpl.format(self.name)
 
         self.task_name = self._task_name_tmpl.format(self.name)
 
@@ -31,16 +31,16 @@ class GroupType:
 COMPLEX_GROUP_TYPE = GroupType('complex')
 
 
-def create_group_map_model(group_type, base):
+def create_group_association_model(group_type, base):
     """
-    Create a SQLAlchemy model representing the mapping of data to groups.
+    Create a SQLAlchemy model representing the association of data to groups.
 
     Args:
         group_type (GroupType): Type of group model to create.
         base (Base): Declarative base of database schema to add model to.
 
     Returns:
-        SQLALchemy model of group mapping. Depending on `group_type`.
+        SQLALchemy model of TS auth group association defined by `group_type`.
     """
     return type(
         group_type.model_name,
@@ -50,6 +50,6 @@ def create_group_map_model(group_type, base):
             '__tablename__': group_type.table_name,
             '__table_args__ ': {'schema': SCHEMA},
             'group_uuid': Column(UUID(as_uuid=True), primary_key=True),
-            group_type.map_column_name: Column(UUID(as_uuid=True), primary_key=True)
+            group_type.member_column_name: Column(UUID(as_uuid=True), primary_key=True)
         }
     )

--- a/thunderstorm_auth/group.py
+++ b/thunderstorm_auth/group.py
@@ -1,4 +1,3 @@
-import kombu.common
 from sqlalchemy import Column
 from sqlalchemy.dialects.postgresql import UUID
 
@@ -13,7 +12,7 @@ def _camel_case(value):
 class GroupType:
     """Definition of a auth group type.
 
-    Provides sync task name, task queue and model/table names.
+    Provides sync task name, model name, table names, mapping column name.
     """
 
     _table_name_tmpl = '{}_group_map'
@@ -27,8 +26,6 @@ class GroupType:
         self.map_column_name = self._map_column_name_tmpl.format(self.name)
 
         self.task_name = self._task_name_tmpl.format(self.name)
-
-        self.queue = kombu.common.Broadcast(self.task_name)
 
 
 COMPLEX_GROUP_TYPE = GroupType('complex')

--- a/thunderstorm_auth/setup.py
+++ b/thunderstorm_auth/setup.py
@@ -1,4 +1,4 @@
-from thunderstorm_auth.tasks import group_sync_task
+from thunderstorm_auth.tasks import group_sync_task, group_sync_queue
 
 
 def init_group_sync_tasks(celery_app, db_session, group_models):
@@ -18,7 +18,12 @@ def init_group_sync_tasks(celery_app, db_session, group_models):
 
     for group_model in group_models:
         group_type = group_model.__ts_group_type__
-        celery_app.conf.task_queues.append(group_type.queue)
+
+        sync_queue = group_sync_queue(
+            group_type=group_type,
+            celery_main=celery_app.main
+        )
+        celery_app.conf.task_queues.append(sync_queue)
 
         sync_task = group_sync_task(
             model=group_model,

--- a/thunderstorm_auth/setup.py
+++ b/thunderstorm_auth/setup.py
@@ -1,0 +1,27 @@
+from thunderstorm_auth.tasks import group_sync_task
+
+
+def init_group_sync_tasks(celery_app, db_session, group_models):
+    """Initialize a Celery app with sync tasks for auth group models.
+
+    For each group model, registers the model's queue to subscribe to and
+    creates and registers the sync task.
+
+    Args:
+        celery_app (Celery): Celery app to register the sync tasks with.
+        db_session (Session): Database session used to sync the model records.
+        group_models (list): The Thunderstorm auth group models to synchronize.
+    """
+
+    if not celery_app.conf.task_queues:
+        celery_app.conf.task_queues = []
+
+    for group_model in group_models:
+        group_type = group_model.__ts_group_type__
+        celery_app.conf.task_queues.append(group_type.queue)
+
+        sync_task = group_sync_task(
+            model=group_model,
+            db_session=db_session
+        )
+        celery_app.register_task(sync_task)

--- a/thunderstorm_auth/tasks.py
+++ b/thunderstorm_auth/tasks.py
@@ -1,0 +1,133 @@
+import celery.task
+from sqlalchemy.exc import SQLAlchemyError
+
+
+def group_sync_task(model, db_session):
+    """Create a sync task for a group model.
+
+    Creates a task which is not registered with any app. The task should be
+    created and registered to an app using
+    `thunderstorm_auth.setup.init_group_sync_tasks`.
+
+    Task takes two args, `group_uuid`, `members`: the UUID of the group to
+    update and a list of UUIDs of the latest members of that group. The task
+    updates the members by adding new member records and deleting ones no
+    longer reported.
+
+    Args:
+        model (Base): Group map model to define the task for.
+        db_session: Session object used to perform the inserts/deletes.
+
+    Returns:
+        Task: Celery task to sync group data.
+    """
+    task_name = model.__ts_group_type__.task_name
+
+    @celery.task.task(name=task_name)
+    def sync_group_data(group_uuid, members):
+        """Synchronizes group membership data.
+
+        Updates the group membership by adding new member records and deleting
+        ones no longer reported.
+
+        Args:
+            group_uuid (UUID): UUID of group to synchronize.
+            members (list): list of UUIDs of desired group members.
+        """
+        current_members = get_current_members(db_session, model, group_uuid)
+        latest_members = set(members)
+
+        removed = current_members - latest_members
+        added = latest_members - current_members
+
+        delete_group_maps(
+            db_session,
+            model,
+            group_uuid,
+            removed
+        )
+        add_group_maps(
+            db_session,
+            model,
+            group_uuid,
+            added
+        )
+        try:
+            db_session.commit()
+        except SQLAlchemyError:
+            db_session.rollback()
+            raise
+
+    return sync_group_data
+
+
+def get_current_members(db_session, model, group_uuid):
+    """The current members of a group.
+
+    Args:
+        db_session (Session): Database session used to query the records.
+        model (Base): Group map model being queried.
+        group_uuid (UUID): UUID of the group whose members to fetch
+
+    Returns:
+        set: Set of UUIDs of current members.
+    """
+    group_column = getattr(model, 'group_uuid')
+
+    members = db_session.query(
+        model
+    ).filer(
+        group_column == group_uuid
+    )
+
+    def member_column(item):
+        member_column_name = model.__ts_group_type__.member_column_name
+        return getattr(item, member_column_name)
+
+    return {
+        member_column(member)
+        for member in members
+    }
+
+
+def delete_group_maps(db_session, model, group_uuid, removed):
+    """Delete group members.
+
+    Args:
+        db_session (Session): Database session used to delete the records.
+        model (Base): Group map model being updated.
+        group_uuid (UUID): UUID of the group whose members to fetch
+        removed (set): UUIDs of members being removed.
+    """
+    group_column = getattr(model, 'group_uuid')
+    member_column = getattr(model, model.__ts_group_type__.member_column_name)
+
+    db_session.query(
+        model
+    ).filter(
+        group_column == group_uuid,
+        member_column.in_(removed)
+    ).delete(
+        synchronize_session=False
+    )
+
+
+def add_group_maps(db_session, model, group_uuid, added):
+    """Add members to a group.
+
+    Args:
+        db_session (Session): Database session used to create the records.
+        model (Base): Group map model being updated.
+        group_uuid (UUID): UUID of the group whose members to fetch
+        added (set): UUIDs of members being added.
+    """
+    group_column = getattr(model, 'group_uuid')
+    member_column = getattr(model, model.__ts_group_type__.member_column_name)
+
+    db_session.bulk_insert_mappings(model, [
+        {
+            group_column: group_uuid,
+            member_column: member_id
+        }
+        for member_id in added
+    ])

--- a/thunderstorm_auth/tasks.py
+++ b/thunderstorm_auth/tasks.py
@@ -1,5 +1,26 @@
 import celery.task
+import kombu.common
 from sqlalchemy.exc import SQLAlchemyError
+
+
+def group_sync_queue(group_type, celery_main):
+    """Create a queue for group sync tasks.
+
+    Queue is a broadcast queue and is unique per group type and per service.
+
+    Args:
+        group_type (GroupType): Group type to create the queue for.
+        celery_main (str): Value of `celery_app.main` for the service adding
+            the queue.
+
+    Returns:
+        kombu.common.Broadcast: Queue group sync tasks will be published to.
+    """
+    queue_name = '{task}.bcast.{service}'.format(
+        task=group_type.task_name,
+        service=celery_main
+    )
+    return kombu.common.Broadcast(group_type.task_name, queue=queue_name)
 
 
 def group_sync_task(model, db_session):


### PR DESCRIPTION
@artsalliancemedia/thunderstorm 

Adds the ability to simply add group mapping models to your service DB schema.
```
from sqlalchemy.ext.declarative import declarative_base
from thunderstorm_auth.group import create_group_map_model, COMPLEX_GROUP_TYPE

Base = declarative_base()

ComplexGroupComplexMap = create_group_map_model(COMPLEX_GROUP_TYPE, Base)
```

And provides an init function for setting up your Celery app with sync tasks and queues to receive updates from.
```
from my_service import db, models
from my_service.tasks import celery_app
from thunderstorm_auth.setup import init_group_sync_tasks

init_group_sync_tasks(celery_app, db.session, [models.ComplexGroupComplexMap])
```

And that's all you need to add to get the groups added and the celery app listening for and performing group updates.