### PR TITLE
[feature] Query filterer helper and test database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: python:3.4-slim
     command: /bin/bash run_test.sh
     working_dir: /var/app
+    links:
+      - postgres
     volumes:
       - ./:/var/app
 
@@ -12,6 +14,8 @@ services:
     image: python:3.5-slim
     command: /bin/bash run_test.sh
     working_dir: /var/app
+    links:
+      - postgres
     volumes:
       - ./:/var/app
 
@@ -19,6 +23,8 @@ services:
     image: python:3.6-slim
     command: /bin/bash run_test.sh
     working_dir: /var/app
+    links:
+      - postgres
     volumes:
       - ./:/var/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,11 @@ services:
     working_dir: /var/app
     volumes:
       - ./:/var/app
+
+  postgres:
+    image: postgres:9.6
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - 5432

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
+falcon>=1.3,<1.4
+flake8==3.5.0
+flask>=0.12,<0.13
+psycopg2>=2.7,<2.8
 pytest>=3.0,<4.0
 pytest-cov>=2.5,<3
-flask>=0.12,<0.13
-falcon>=1.3,<1.4
-ipdb
-flake8
+sqlalchemy_utils==0.32.21

--- a/test/sqlalchemy/conftest.py
+++ b/test/sqlalchemy/conftest.py
@@ -1,0 +1,57 @@
+import os
+import sqlalchemy_utils
+import pytest
+from sqlalchemy import create_engine, MetaData
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+
+@pytest.fixture(scope='session')
+def db_uri():
+    host = os.environ.get('DB_HOST', 'postgres')
+    port = os.environ.get('DB_PORT', 5432)
+    username = os.environ.get('DB_USER', 'postgres')
+    password = os.environ.get('DB_PASS', 'postgres')
+    name = os.environ.get('DB_NAME', 'test_auth_lib')
+
+    return 'postgresql://{username}:{password}@{host}:{port}/{name}'.format(
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        name=name
+    )
+
+
+@pytest.fixture(scope='session')
+def test_database(db_uri):
+    sqlalchemy_utils.create_database(db_uri)
+    yield create_engine(db_uri)
+    sqlalchemy_utils.drop_database(db_uri)
+
+
+@pytest.fixture(scope='session')
+def db_connection(test_database):
+    with test_database.connect() as connection:
+        transaction = connection.begin()
+        yield connection
+        transaction.rollback()
+
+
+@pytest.fixture
+def metadata(db_connection):
+    meta = MetaData(bind=db_connection)
+    yield meta
+    meta.drop_all()
+
+
+@pytest.fixture
+def base(metadata):
+    return declarative_base(metadata=metadata)
+
+
+@pytest.fixture
+def db_session(db_connection):
+    session = sessionmaker(bind=db_connection)()
+    yield session
+    session.close()

--- a/test/sqlalchemy/test_group_model.py
+++ b/test/sqlalchemy/test_group_model.py
@@ -1,0 +1,16 @@
+import uuid
+
+from thunderstorm_auth import group
+
+
+def test_create_complex_group_assoc_model_insert(metadata, base, db_session):
+    model = group.create_group_association_model(group.COMPLEX_GROUP_TYPE, base)
+    metadata.create_all()
+    db_session.add(
+        model(
+            group_uuid=uuid.uuid4(),
+            complex_uuid=uuid.uuid4()
+        )
+    )
+    db_session.commit()
+    assert db_session.query(model).count() == 1

--- a/test/sqlalchemy/test_query.py
+++ b/test/sqlalchemy/test_query.py
@@ -1,0 +1,74 @@
+import uuid
+
+import pytest
+from sqlalchemy import Column
+from sqlalchemy.dialects import postgresql as pg
+
+from thunderstorm_auth import group
+from thunderstorm_auth.exceptions import InsufficientPermissions
+from thunderstorm_auth.query import filter_for_user
+from thunderstorm_auth.user import User
+
+
+@pytest.fixture
+def complex_model(base):
+
+    class Complex(base):
+        __tablename__ = 'complex'
+        uuid = Column(pg.UUID(as_uuid=True), primary_key=True)
+
+    return Complex
+
+
+@pytest.fixture
+def complex_assoc_model(base):
+    return group.create_group_association_model(
+        group.COMPLEX_GROUP_TYPE, base
+    )
+
+
+@pytest.fixture
+def models(metadata, complex_model, complex_assoc_model):
+    metadata.create_all()
+    return complex_model, complex_assoc_model
+
+
+def test_query_filter_for_user(db_session, models):
+    complex_model, complex_assoc_model = models
+
+    group_uuid = uuid.uuid4()
+
+    complexes = [complex_model(uuid=uuid.uuid4()) for _ in range(3)]
+    db_session.add_all(complexes)
+
+    complex_associations = [
+        complex_assoc_model(
+            complex_uuid=c.uuid,
+            group_uuid=group_uuid
+        )
+        for c in complexes[:2]
+    ]
+    db_session.add_all(complex_associations)
+
+    user = User(username='test', groups=[group_uuid], permissions=None)
+
+    query = db_session.query(complex_model)
+    filtered_query = filter_for_user(
+        query, user, complex_assoc_model, complex_model.uuid
+    )
+
+    assert query.count() == 3
+    assert filtered_query.count() == 2
+
+
+def test_query_filter_for_user_raises_insufficient_permissions_if_no_groups(
+        db_session, models):
+    complex_model, complex_assoc_model = models
+
+    user = User(username='test', groups=[], permissions=None)
+
+    query = db_session.query(complex_model)
+    with pytest.raises(InsufficientPermissions):
+        filter_for_user(
+            query, user, complex_assoc_model, complex_model.uuid
+        )

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'

--- a/thunderstorm_auth/exceptions.py
+++ b/thunderstorm_auth/exceptions.py
@@ -29,3 +29,7 @@ class BrokenTokenError(TokenError):
 
 class ExpiredTokenError(TokenError):
     pass
+
+
+class InsufficientPermissions(ThunderstormAuthError):
+    pass

--- a/thunderstorm_auth/query.py
+++ b/thunderstorm_auth/query.py
@@ -1,0 +1,40 @@
+from sqlalchemy import and_
+
+from thunderstorm_auth.exceptions import InsufficientPermissions
+
+
+def filter_for_user(query, user, group_assoc_model, join_column):
+    """Filter a query based on a user's groups.
+
+    Args:
+        query (Query): Query to filter.
+        user (User): User querying results.
+        group_assoc_model (Base): The group association model to join to in
+            the query.
+        join_column (InstrumentedAttribute): The column the group association
+            table will join on.
+
+    Returns:
+        Query: Filtered query
+    """
+    group_type = group_assoc_model.__ts_group_type__
+
+    # TODO:
+    # When more group types are created, the groups will need to be grouped
+    # by group type. Will be wasteful to filter by all the user's groups.
+
+    if not user.groups:
+        # saves performing an expensive `WHERE col IN ()` query
+        raise InsufficientPermissions('User has no group associations.')
+
+    group_member_column = getattr(
+        group_assoc_model,
+        group_type.member_column_name
+    )
+    return query.join(
+        group_assoc_model,
+        and_(
+            group_member_column == join_column,
+            group_assoc_model.group_uuid.in_(user.groups)
+        )
+    )


### PR DESCRIPTION
@artsalliancemedia/thunderstorm 

Adds database setup fixtures to allow testing integration testing of things like group models and query manipulators.

Adds a `filter_for_user` function which uses a user's groups to filter a query.