### PR TITLE
[fix] handle case where token is encrypted with wrong key

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,6 +65,16 @@ def valid_token(private_key, key_id, token_data):
 
 
 @pytest.fixture
+def valid_token_signed_with_incorrect_key(key_id, token_data, alternate_private_key):
+    return utils.encode_token(
+        # token should have been signed with private_key
+        alternate_private_key,
+        key_id,
+        token_data
+    )
+
+
+@pytest.fixture
 def invalid_token():
     # using a junk string here rather than a truncated token as truncated
     # tokens do not trigger the desired error

--- a/test/test_decoder.py
+++ b/test/test_decoder.py
@@ -1,7 +1,8 @@
 import pytest
 
 from thunderstorm_auth.decoder import decode_token, get_kid_and_alg_headers_from_token
-from thunderstorm_auth.exceptions import ExpiredTokenError, BrokenTokenError, MissingKeyErrror
+from thunderstorm_auth.exceptions import (ExpiredTokenError, BrokenTokenError, MissingKeyErrror,
+                                          TokenDecodeError)
 
 
 def test_get_decoded_token_returns_if_jwt_valid(valid_token, jwk_set):
@@ -48,3 +49,8 @@ def test_get_headers_from_token_returns_key_id_and_signing_algorithm(valid_token
 def test_get_headers_from_token_raises_BrokenTokenError_if_headers_are_missing():
     with pytest.raises(BrokenTokenError):
         get_kid_and_alg_headers_from_token('not a token')
+
+
+def test_decode_valid_token_with_invalid_key(valid_token_signed_with_incorrect_key, jwk_set):
+    with pytest.raises(TokenDecodeError):
+        decode_token(valid_token_signed_with_incorrect_key, jwk_set)

--- a/thunderstorm_auth/decoder.py
+++ b/thunderstorm_auth/decoder.py
@@ -4,7 +4,8 @@ import jwt
 import jwt.algorithms
 
 from thunderstorm_auth import DEFAULT_LEEWAY
-from thunderstorm_auth.exceptions import ExpiredTokenError, BrokenTokenError, MissingKeyErrror
+from thunderstorm_auth.exceptions import (ExpiredTokenError, BrokenTokenError, MissingKeyErrror,
+                                          TokenDecodeError)
 
 
 def decode_token(token, jwks, leeway=DEFAULT_LEEWAY):
@@ -40,6 +41,8 @@ def decode_token(token, jwks, leeway=DEFAULT_LEEWAY):
         raise ExpiredTokenError(
             'Auth token expired. Please retry with a new token.'
         )
+    except jwt.exceptions.DecodeError as ex:
+        raise TokenDecodeError('An error occurred while decoding your token: {}'.format(ex))
     except BrokenTokenError as ex:
         raise BrokenTokenError(ex)
     except KeyError:

--- a/thunderstorm_auth/exceptions.py
+++ b/thunderstorm_auth/exceptions.py
@@ -17,6 +17,10 @@ class MissingKeyErrror(TokenError):
     pass
 
 
+class TokenDecodeError(TokenError):
+    pass
+
+
 class TokenHeaderMissing(TokenError):
 
     def __init__(self):


### PR DESCRIPTION
Adds new Exception Type
Handles case where a token has been signed with a key different to the one specified in the 'kid' header
Adds a test to cover this case
Adds a new fixture for this test