### PR TITLE
Change setup to use one queue with many bindings

### DIFF
--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import celery
+import kombu
 import pytest
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -28,10 +29,14 @@ def models(group_types):
 @pytest.fixture
 def celery_app(group_types):
     foo_type, bar_type = group_types
-    app = celery.Celery()
+    app = celery.Celery('example_service')
     yield app
     app.tasks.unregister(foo_type.task_name)
     app.tasks.unregister(bar_type.task_name)
+
+
+def test_exchange_name():
+    assert setup.EXCHANGE.name == 'ts_auth.group'
 
 
 def test_init_group_sync_tasks(celery_app, models, group_types):
@@ -43,8 +48,31 @@ def test_init_group_sync_tasks(celery_app, models, group_types):
     setup.init_group_sync_tasks(celery_app, db_session, models)
 
     # assert
-    queue_names = {q.name for q in celery_app.conf.task_queues}
-    assert foo_type.queue_name(celery_app.main) in queue_names
-    assert bar_type.queue_name(celery_app.main) in queue_names
     assert foo_type.task_name in celery_app.tasks
     assert bar_type.task_name in celery_app.tasks
+
+
+def test_init_group_sync_queue(celery_app, models, group_types):
+    # arrange
+    foo_type, bar_type = group_types
+    db_session = mock.Mock()
+
+    # act
+    setup.init_group_sync_tasks(celery_app, db_session, models)
+
+    # assert
+    queues = [
+        q for q in celery_app.conf.task_queues
+        if q.name != celery_app.conf.task_default_queue
+    ]
+    assert len(queues) == 1, queues
+    queue = queues[0]
+    assert isinstance(queue, kombu.Queue)
+    assert queue.name == 'example_service.ts_auth.group'
+    assert {binding.exchange for binding in queue.bindings} == {
+        setup.EXCHANGE
+    }
+    assert {binding.routing_key for binding in queue.bindings} == {
+        foo_type.routing_key,
+        bar_type.routing_key
+    }

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import celery
 import celery.task
-import kombu.common
 import pytest
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -27,24 +26,6 @@ def _teardown_celery_app(group_type):
     yield app
     if group_type.task_name in app.tasks:
         app.tasks.unregister(group_type.task_name)
-
-
-def test_exchange_name():
-    assert tasks.EXCHANGE.name == 'ts_auth.group'
-
-
-def test_create_group_sync_queue(group_type):
-    # arrange
-    celery_app = celery.Celery('test_app')
-
-    # act
-    queue = tasks.group_sync_queue(group_type, celery_app.main)
-
-    # assert
-    assert isinstance(queue, kombu.Queue)
-    assert queue.name == 'test_app.ts_auth.group.example'
-    assert queue.exchange == tasks.EXCHANGE
-    assert queue.routing_key == 'group.example'
 
 
 def test_create_group_sync_task(model):

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'

--- a/thunderstorm_auth/setup.py
+++ b/thunderstorm_auth/setup.py
@@ -1,43 +1,73 @@
 import kombu
 
-from thunderstorm_auth.tasks import group_sync_task, group_sync_queue
+from thunderstorm_auth.tasks import group_sync_task
+
+
+EXCHANGE = kombu.Exchange('ts_auth.group')
 
 
 def init_group_sync_tasks(celery_app, db_session, group_models):
-    """Initialize a Celery app with sync tasks for auth group models.
+    """
+    Initialize a Celery app with a queue and sync tasks for auth group models.
 
-    For each group model, registers the model's queue to subscribe to and
-    creates and registers the sync task.
+    Creates and registers a sync task for each group association model.
+    Creates a queue for the service to consume these tasks from and binds the
+    queue to the `ts_auth.group` exchange, binding it with the routing keys of
+    the group types of the group association models.
 
     Args:
         celery_app (Celery): Celery app to register the sync tasks with.
         db_session (Session): Database session used to sync the model records.
         group_models (list): The Thunderstorm auth group models to synchronize.
     """
+    _register_task_queue(celery_app, group_models)
+    _register_sync_tasks(celery_app, db_session, group_models)
 
+
+def _register_task_queue(celery_app, group_models):
     # If task_queues is None, default queue is used,
     # manually add here so we don't exclude.
-    # Override before calling init_group_sync_tasks to prevent this.
+    # Override value before calling init_group_sync_tasks to prevent this.
     if celery_app.conf.task_queues is None:
         celery_app.conf.task_queues = [
             kombu.Queue(celery_app.conf.task_default_queue)
         ]
 
-    for group_model in group_models:
-        _register_group_task_and_queue(group_model, celery_app, db_session)
-
-
-def _register_group_task_and_queue(group_model, celery_app, db_session):
-    group_type = group_model.__ts_group_type__
-
+    routing_keys = [
+        group_model.__ts_group_type__.routing_key
+        for group_model in group_models
+    ]
     sync_queue = group_sync_queue(
-        group_type=group_type,
-        celery_main=celery_app.main
+        celery_main=celery_app.main,
+        routing_keys=routing_keys
     )
     celery_app.conf.task_queues.append(sync_queue)
 
-    sync_task = group_sync_task(
-        model=group_model,
-        db_session=db_session
+
+def _register_sync_tasks(celery_app, db_session, group_models):
+    for group_model in group_models:
+        sync_task = group_sync_task(
+            model=group_model,
+            db_session=db_session
+        )
+        celery_app.register_task(sync_task)
+
+
+def group_sync_queue(celery_main, routing_keys):
+    """Create the queue which group sync tasks will be consumed from.
+
+    Args:
+        celery_main (str): Value of `celery_app.main` for the service adding
+            the queue.
+        routing_keys (list): Routing keys with which to bind to the exchange.
+
+    Returns:
+        kombu.Queue: Queue that group sync tasks will be published to.
+    """
+    return kombu.Queue(
+        '{celery_main}.ts_auth.group'.format(celery_main=celery_main),
+        [
+            kombu.binding(EXCHANGE, routing_key=routing_key)
+            for routing_key in routing_keys
+        ]
     )
-    celery_app.register_task(sync_task)

--- a/thunderstorm_auth/tasks.py
+++ b/thunderstorm_auth/tasks.py
@@ -1,27 +1,5 @@
 import celery
-import kombu
 from sqlalchemy.exc import SQLAlchemyError
-
-
-EXCHANGE = kombu.Exchange('ts_auth.group')
-
-
-def group_sync_queue(group_type, celery_main):
-    """Create a queue object which group sync tasks will be consumed from.
-
-    Args:
-        group_type (GroupType): Group type to create the queue for.
-        celery_main (str): Value of `celery_app.main` for the service adding
-            the queue.
-
-    Returns:
-        kombu.Queue: Queue that group sync tasks will be published to.
-    """
-    return kombu.Queue(
-        name=group_type.queue_name(celery_main),
-        exchange=EXCHANGE,
-        routing_key=group_type.routing_key
-    )
 
 
 def group_sync_task(model, db_session):


### PR DESCRIPTION
@artsalliancemedia/thunderstorm 

Before: one queue per type per service, each bound with that type's routing key.
After: one queue per service, bound many times with each routing key.