### PR TITLE
Add task logging

### DIFF
--- a/thunderstorm_auth/tasks.py
+++ b/thunderstorm_auth/tasks.py
@@ -1,5 +1,11 @@
+import logging
+
 import celery
+from celery.utils.log import get_task_logger
 from sqlalchemy.exc import SQLAlchemyError
+
+logger = get_task_logger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def group_sync_task(model, db_session):
@@ -57,6 +63,9 @@ def group_sync_task(model, db_session):
         except SQLAlchemyError:
             db_session.rollback()
             raise
+
+        logger.info('Updated group: {} - {} members added, {} removed.'
+                    .format(group_uuid, len(added), len(removed)))
 
     return sync_group_data
 


### PR DESCRIPTION
Add logging to the sync_group_data task
Add an if statement to avoid the in predicate being invoked on empty sequences when removing group members: http://docs.sqlalchemy.org/en/rel_1_0/faq/sqlexpressions.html#why-does-col-in-produce-col-col-why-not-1-0