### PR TITLE
Prevent key expiry being logged as error

### DIFF
--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'

--- a/thunderstorm_auth/flask.py
+++ b/thunderstorm_auth/flask.py
@@ -4,7 +4,10 @@ from flask import g
 
 from thunderstorm_auth import TOKEN_HEADER, DEFAULT_LEEWAY
 from thunderstorm_auth.decoder import decode_token
-from thunderstorm_auth.exceptions import TokenError, TokenHeaderMissing, AuthJwksNotSet, ThunderstormAuthError
+from thunderstorm_auth.exceptions import (
+    TokenError, TokenHeaderMissing, AuthJwksNotSet, ThunderstormAuthError,
+    ExpiredTokenError
+)
 from thunderstorm_auth.user import User
 
 try:
@@ -70,5 +73,8 @@ def _get_jwks():
 
 
 def _bad_token(error):
-    current_app.logger.error(error)
+    if isinstance(error, ExpiredTokenError):
+        current_app.logger.info(error)
+    else:
+        current_app.logger.error(error)
     return jsonify(message=str(error)), 401


### PR DESCRIPTION
Addresses this issue in Sentry https://sentry.aamts.io/aam/agent-service/issues/193/