### PR TITLE
TSA-351 JSON logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cryptography>=2.0.3,<3
 celery>=4.0,<4.2
 pyjwt>=1.5.2,<2
 sqlalchemy>=1.1,<1.2
+python-json-logger==0.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-cryptography>=2.0.3,<3
 celery>=4.0,<4.2
+cryptography>=2.0.3,<3
 pyjwt>=1.5.2,<2
-sqlalchemy>=1.1,<1.2
 python-json-logger==0.1.8
+requests==2.18.4
+sqlalchemy>=1.1,<1.2

--- a/test/logging/conftest.py
+++ b/test/logging/conftest.py
@@ -1,0 +1,36 @@
+import logging as pylogging
+
+import flask
+import pytest
+
+from thunderstorm_auth import logging
+
+
+@pytest.fixture
+def record():
+    return pylogging.LogRecord(
+        'test.name',
+        pylogging.INFO,
+        '/example/path.py',
+        123,
+        'example message',
+        tuple(),
+        dict(),
+        None
+    )
+
+
+@pytest.fixture
+def formatter():
+    return logging.JSONFormatter('%(message)s')
+
+
+@pytest.fixture
+def flask_app(jwk_set):
+    app = flask.Flask('test_app')
+
+    @app.route('/')
+    def hello_world():
+        return 'Hello, World!'
+
+    return app

--- a/test/logging/test_celery_logging.py
+++ b/test/logging/test_celery_logging.py
@@ -67,9 +67,9 @@ def test_celery_task_filter_with_no_task(
     record = filter.filter(record)
 
     # assert
-    assert record.task_id == '???'
+    assert record.task_id is None
     assert record.request_id is None
-    assert record.task_name == '???'
+    assert record.task_name is None
 
 
 @mock.patch('thunderstorm_auth.logging.celery.get_current_task')
@@ -86,6 +86,6 @@ def test_celery_task_filter_with_task_no_request(
     record = filter.filter(record)
 
     # assert
-    assert record.task_id == '???'
+    assert record.task_id is None
     assert record.request_id is None
-    assert record.task_name == '???'
+    assert record.task_name is None

--- a/test/logging/test_celery_logging.py
+++ b/test/logging/test_celery_logging.py
@@ -1,0 +1,91 @@
+from unittest import mock
+
+from thunderstorm_auth.logging.celery import (
+    get_celery_request_id,
+    CeleryTaskFilter
+)
+
+
+@mock.patch('thunderstorm_auth.logging.celery.get_current_task')
+def test_celery_request_id(mock_get_current_task):
+    # arrange
+    mock_request = mock.Mock()
+    mock_request.get.return_value = 'request-id'
+    mock_task = mock.Mock()
+    mock_task.request = mock_request
+    mock_get_current_task.return_value = mock_task
+
+    # assert
+    assert get_celery_request_id() == 'request-id'
+    mock_request.get.assert_called_with('x_request_id', None)
+
+
+def test_celery_request_id_passed_in_request():
+    # arrange
+    mock_request = mock.Mock()
+    mock_request.get.return_value = 'request-id'
+    mock_task = mock.Mock()
+    mock_task.request = mock_request
+
+    # assert
+    assert get_celery_request_id(mock_request) == 'request-id'
+    mock_request.get.assert_called_with('x_request_id', None)
+
+
+@mock.patch('thunderstorm_auth.logging.celery.get_celery_request_id')
+@mock.patch('thunderstorm_auth.logging.celery.get_current_task')
+def test_celery_task_filter_with_task_and_request(
+    mock_get_current_task, mock_get_celery_request_id, record
+):
+    # arrange
+    mock_task = mock.Mock()
+    mock_task.request = mock.Mock()
+    mock_task.request.id = 'task-id'
+    mock_task.name = 'task-name'
+    mock_get_celery_request_id.return_value = 'request-id'
+    mock_get_current_task.return_value = mock_task
+    filter = CeleryTaskFilter()
+
+    # act
+    record = filter.filter(record)
+
+    # assert
+    assert record.task_id == 'task-id'
+    assert record.request_id == 'request-id'
+    assert record.task_name == 'task-name'
+
+
+@mock.patch('thunderstorm_auth.logging.celery.get_current_task')
+def test_celery_task_filter_with_no_task(
+    mock_get_current_task, record
+):
+    # arrange
+    mock_get_current_task.return_value = None
+    filter = CeleryTaskFilter()
+
+    # act
+    record = filter.filter(record)
+
+    # assert
+    assert record.task_id == '???'
+    assert record.request_id is None
+    assert record.task_name == '???'
+
+
+@mock.patch('thunderstorm_auth.logging.celery.get_current_task')
+def test_celery_task_filter_with_task_no_request(
+    mock_get_current_task, record
+):
+    # arrange
+    mock_task = mock.Mock()
+    mock_task.request = None
+    mock_get_current_task.return_value = mock_task
+    filter = CeleryTaskFilter()
+
+    # act
+    record = filter.filter(record)
+
+    # assert
+    assert record.task_id == '???'
+    assert record.request_id is None
+    assert record.task_name == '???'

--- a/test/logging/test_flask_logging.py
+++ b/test/logging/test_flask_logging.py
@@ -1,0 +1,55 @@
+from unittest import mock
+
+from flask import g
+
+from thunderstorm_auth.logging.flask import (
+    get_flask_request_id,
+    FlaskRequestIdFilter,
+    FlaskJSONFormatter,
+)
+
+
+def test_flask_request_id_from_global(flask_app):
+    with flask_app.test_request_context('/'):
+        g.request_id = 'global-request-id'
+
+        assert get_flask_request_id() == 'global-request-id'
+
+
+def test_flask_request_id_from_header(flask_app):
+    headers = {
+        'TS-Request-ID': 'header-request-id'
+    }
+    with flask_app.test_request_context('/', headers=headers):
+        assert get_flask_request_id() == 'header-request-id'
+
+
+@mock.patch('thunderstorm_auth.logging.flask.uuid.uuid4')
+def test_flask_request_id_from_new(mock_uuid4, flask_app):
+    with flask_app.test_request_context('/'):
+        mock_uuid4.return_value = 'new-request-id'
+
+        assert get_flask_request_id() == 'new-request-id'
+
+
+def test_flask_request_id_filter(flask_app, record):
+    with flask_app.test_request_context('/'):
+        g.request_id = 'global-request-id'
+
+        filter = FlaskRequestIdFilter()
+        record = filter.filter(record)
+
+        assert record.request_id == 'global-request-id'
+
+
+def test_flask_json_formatter(flask_app, record):
+    with flask_app.test_request_context('/'):
+        g.request_id = 'global-request-id'
+
+        formatter = FlaskJSONFormatter('%(message)s')
+
+        log_record = {}
+
+        formatter.add_fields(log_record, record, {})
+
+        assert log_record['request_id'] == 'global-request-id'

--- a/test/logging/test_logging.py
+++ b/test/logging/test_logging.py
@@ -1,0 +1,114 @@
+import pytest
+
+from thunderstorm_auth import logging
+
+
+def test_get_request_id_with_no_getters():
+    # arrange
+    del logging._ID_GETTERS[:]
+
+    # assert
+    assert logging.get_request_id() is None
+
+
+def test_get_request_id_with_one_getter():
+    # arrange
+    del logging._ID_GETTERS[:]
+    logging._register_id_getter(lambda: 'one')
+
+    # assert
+    assert logging.get_request_id() == 'one'
+
+
+def test_get_request_id_with_two_getters():
+    # arrange
+    del logging._ID_GETTERS[:]
+    logging._register_id_getter(lambda: 'one')
+    logging._register_id_getter(lambda: 'two')
+
+    # assert
+    assert logging.get_request_id() == 'one'
+
+
+class TestJSONFormatter:
+    def test_required_fields_are_added(self, formatter, record):
+        # arrange
+        log_record = {}
+
+        # act
+        formatter.add_fields(log_record, record, {})
+
+        # assert
+        assert log_record['name'] == 'test.name'
+        assert log_record['levelname'] == 'INFO'
+        assert log_record['pathname'] == '/example/path.py'
+        assert log_record['lineno'] == 123
+
+    def test_missing_required_fields_cause_failure(self, formatter, record):
+        # arrange
+        log_record = {}
+        delattr(record, 'name')
+
+        # assert
+        with pytest.raises(AttributeError):
+            formatter.add_fields(log_record, record, {})
+
+    def test_grouping_fields_are_added(self, formatter, record):
+        # arrange
+        formatter = logging.JSONFormatter(
+            '%(message)s',
+            ts_log_type='test-type',
+            ts_service='test-service'
+        )
+        log_record = {}
+
+        # act
+        formatter.add_fields(log_record, record, {})
+
+        # assert
+        assert log_record['service'] == 'test-service'
+        assert log_record['log_type'] == 'test-type'
+
+    def test_grouping_fields_defaults(self, formatter, record):
+        # arrange
+        log_record = {}
+
+        # act
+        formatter.add_fields(log_record, record, {})
+
+        # assert
+        assert log_record['service'] == 'unknown'
+        assert log_record['log_type'] == 'unknown'
+
+    def test_request_id_is_added_if_present(self, formatter, record):
+        # arrange
+        log_record = {}
+        record.request_id = 'test-id'
+
+        # act
+        formatter.add_fields(log_record, record, {})
+
+        # assert
+        assert log_record['request_id']
+        assert log_record['data']['request_id']
+
+    def test_request_id_is_not_added_if_missing(self, formatter, record):
+        # arrange
+        log_record = {}
+
+        # act
+        formatter.add_fields(log_record, record, {})
+
+        # assert
+        assert 'request_id' not in log_record
+        assert 'data' not in log_record
+
+    def test_timestamp_is_added(self, formatter, record):
+        # arrange
+        log_record = {}
+
+        # act
+        formatter.add_fields(log_record, record, {})
+
+        # assert
+        assert 'timestamp' in log_record

--- a/test/logging/test_requests.py
+++ b/test/logging/test_requests.py
@@ -1,0 +1,38 @@
+from unittest import mock
+
+from thunderstorm_auth.logging import requests
+
+
+@mock.patch('thunderstorm_auth.logging.requests._get')
+@mock.patch('thunderstorm_auth.logging.requests._get_request_id')
+def test_get(mock_get_request_id, mock_get):
+    mock_get_request_id.return_value = 'request-id'
+
+    requests.get('/')
+
+    mock_get.assert_called_with('/', headers={'TS-Request-ID': 'request-id'})
+
+
+@mock.patch('thunderstorm_auth.logging.requests._get')
+@mock.patch('thunderstorm_auth.logging.requests._get_request_id')
+def test_get_with_headers(mock_get_request_id, mock_get):
+    mock_get_request_id.return_value = 'request-id'
+
+    requests.get('/', headers={'foo': 'bar'})
+
+    mock_get.assert_called_with('/', headers={
+        'TS-Request-ID': 'request-id',
+        'foo': 'bar',
+    })
+
+
+@mock.patch('thunderstorm_auth.logging.requests._get')
+@mock.patch('thunderstorm_auth.logging.requests._get_request_id')
+def test_get_with_request_id(mock_get_request_id, mock_get):
+    mock_get_request_id.return_value = 'request-id'
+
+    requests.get('/', headers={'TS-Request-ID': 'my-id'})
+
+    mock_get.assert_called_with('/', headers={
+        'TS-Request-ID': 'my-id',
+    })

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.1.5'
+__version__ = '0.2.0'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'

--- a/thunderstorm_auth/logging/__init__.py
+++ b/thunderstorm_auth/logging/__init__.py
@@ -1,0 +1,73 @@
+import datetime
+
+from pythonjsonlogger.jsonlogger import JsonFormatter as BaseJSONFormatter
+
+
+__all__ = [
+    'JSONFormatter', 'get_request_id'
+]
+
+
+REQUIRED_FIELDS = [
+    'name', 'levelname', 'pathname', 'lineno'
+]
+
+
+class JSONFormatter(BaseJSONFormatter):
+    """JSON logging Formatter for Thunderstorm apps
+
+    Adds thunderstorm fields to JSON logging
+    """
+    def __init__(self, *args, **kwargs):
+        self._ts_log_type = kwargs.pop('ts_log_type', 'unknown')
+        self._ts_service = kwargs.pop('ts_service', 'unknown')
+        super().__init__(*args, **kwargs)
+
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        log_record = self._add_required_fields(log_record, record)
+        log_record = self._add_grouping_fields(log_record, record)
+        log_record = self._add_request_id(log_record, record)
+        log_record = self._add_timestamp(log_record, record)
+
+    def _add_required_fields(self, log_record, record):
+        log_record.update({
+            name: getattr(record, name) for name in REQUIRED_FIELDS
+        })
+
+        return log_record
+
+    def _add_grouping_fields(self, log_record, record):
+        log_record.update({
+            'service': self._ts_service,
+            'log_type': self._ts_log_type,
+        })
+
+        return log_record
+
+    def _add_request_id(self, log_record, record):
+        if getattr(record, 'request_id', None):
+            log_record['request_id'] = record.request_id
+            log_record.setdefault('data', {})
+            log_record['data']['request_id'] = record.request_id
+
+        return log_record
+
+    def _add_timestamp(self, log_record, record):
+        log_record['timestamp'] = datetime.datetime.utcnow().isoformat()
+
+        return log_record
+
+
+_ID_GETTERS = []
+
+
+def _register_id_getter(getter):
+    _ID_GETTERS.append(getter)
+
+
+def get_request_id():
+    for getter in _ID_GETTERS:
+        request_id = getter()
+        if request_id:
+            return request_id

--- a/thunderstorm_auth/logging/__init__.py
+++ b/thunderstorm_auth/logging/__init__.py
@@ -1,3 +1,10 @@
+"""Core JSON logging module
+
+You probably do not want to use this directly.
+See:
+    thunderstorm_auth.logging.flask
+    thunderstorm_auth.logging.celery
+"""
 import datetime
 
 from pythonjsonlogger.jsonlogger import JsonFormatter as BaseJSONFormatter
@@ -67,6 +74,16 @@ def _register_id_getter(getter):
 
 
 def get_request_id():
+    """Return the current request ID
+
+    Return the current request ID from whichever ID getters have been
+    registered. An ID getter is registered when it's module is included.
+    For example; if the ``thunderstorm_auth.logging.flask`` module is imported
+    the ``get_flask_request_id`` is registered.
+
+    Returns:
+        str the current request ID
+    """
     for getter in _ID_GETTERS:
         request_id = getter()
         if request_id:

--- a/thunderstorm_auth/logging/celery.py
+++ b/thunderstorm_auth/logging/celery.py
@@ -64,9 +64,9 @@ class CeleryTaskFilter(logging.Filter):
             record.request_id = get_celery_request_id(task.request)
             record.task_name = task.name
         else:
-            record.task_id = '???'
+            record.task_id = None
             record.request_id = None
-            record.task_name = '???'
+            record.task_name = None
 
         return record
 

--- a/thunderstorm_auth/logging/celery.py
+++ b/thunderstorm_auth/logging/celery.py
@@ -1,0 +1,95 @@
+import logging
+
+import celery
+from celery import Task as CeleryTask
+from celery._state import get_current_task
+
+from . import JSONFormatter, get_request_id, _register_id_getter
+
+
+_CELERY_X_HEADER = 'x_request_id'
+
+
+def get_celery_request_id(request=None):
+    if not request:
+        task = get_current_task()
+        if task and task.request:
+            request = task.request
+    if request:
+        return request.get(_CELERY_X_HEADER, None)
+
+
+_register_id_getter(get_celery_request_id)
+
+
+class CeleryTaskFilter(logging.Filter):
+    """Celery logging filter
+
+    This adds in the task name and ID and also the request ID if it was
+    added by the `CeleryRequestIDTask'
+    """
+    def filter(self, record):
+        task = get_current_task()
+        if task and task.request:
+            record.task_id = task.request.id
+            record.request_id = get_celery_request_id(task.request)
+            record.task_name = task.name
+        else:
+            record.task_id = '???'
+            record.request_id = None
+            record.task_name = '???'
+
+        return record
+
+
+class CeleryRequestIDTask(CeleryTask):
+    """Celery Task that adds request ID header
+
+    This adds the request ID as a celery header so that it can be logged
+    in celery task logs
+    """
+    def apply_async(self, *args, **kwargs):
+        kwargs.setdefault('headers', {})
+        request_id = get_request_id()
+        kwargs['headers'][_CELERY_X_HEADER] = request_id
+
+        return super().apply_async(*args, **kwargs)
+
+
+def on_celery_setup_logging(service_name):
+    """Set up celery logging
+
+    This should be hooked up to the celery `setup_logging` signal to
+    override celery's logging
+    """
+    def _get_celery_handler(log_format):
+        handler = logging.StreamHandler()
+        formatter = JSONFormatter(
+            log_format,
+            ts_log_type='celery',
+            ts_service=service_name
+        )
+        handler.setFormatter(formatter)
+
+        return handler
+
+    def do_setup_logging(**kwargs):
+        logging.getLogger().addHandler(
+            _get_celery_handler('%(name)s %(levelname)s %(message)s')
+        )
+
+        handler = _get_celery_handler(
+            '[%(levelname)s/%(processName)s] %(message)s'
+        )
+        celery.utils.log.worker_logger.addHandler(handler)
+        celery.utils.log.worker_logger.propagate = False
+
+        handler = _get_celery_handler(
+            '[%(levelname)s/%(processName)s]'
+            '%(task_name)s %(task_id)s %(message)s'
+        )
+        handler.addFilter(CeleryTaskFilter())
+        celery.utils.log.task_logger.addHandler(handler)
+        celery.utils.log.task_logger.propagate = False
+
+    return do_setup_logging

--- a/thunderstorm_auth/logging/flask.py
+++ b/thunderstorm_auth/logging/flask.py
@@ -1,3 +1,12 @@
+"""Module for integrating JSON logging with Flask
+
+Usage:
+    >>> from flask import Flask
+    >>> from thunderstorm_auth.logging.flask import init_app as init_logging
+    >>>
+    >>> app = Flask(__init__)
+    >>> init_logging(app)
+"""
 import logging
 import os
 import uuid
@@ -14,6 +23,17 @@ __all__ = [
 
 
 def get_flask_request_id():
+    """Return the request ID from the Flask request context
+
+    If there is a Flask request context but there is no ``request_id``
+    then first we look for a ``TS-Request-ID`` header. If that is also
+    not there we generate a new string uuid4.
+
+    Importing this module will register this getter with ``get_request_id``.
+
+    Returns:
+        str: the current request ID
+    """
     if has_request_context():
         if 'request_id' not in g:
             g.request_id = request.headers.get(
@@ -26,7 +46,11 @@ _register_id_getter(get_flask_request_id)
 
 
 def init_app(app: Flask):
-    """Initialise logging on a Flask app"""
+    """Initialise logging on a Flask app
+
+    Usage:
+        >>> init_app(app)
+    """
     handler = logging.StreamHandler()
     log_format = '%(levelname)s %(message)s'
 

--- a/thunderstorm_auth/logging/flask.py
+++ b/thunderstorm_auth/logging/flask.py
@@ -1,0 +1,103 @@
+import logging
+import os
+import uuid
+
+from flask import g, request, Flask
+from flask.ctx import has_request_context
+
+from . import JSONFormatter, _register_id_getter
+
+
+__all__ = [
+    'init_app'
+]
+
+
+def get_flask_request_id():
+    if has_request_context():
+        if 'request_id' not in g:
+            g.request_id = request.headers.get(
+                'TS-Request-ID', str(uuid.uuid4())
+            )
+        return g.request_id
+
+
+_register_id_getter(get_flask_request_id)
+
+
+def init_app(app: Flask):
+    """Initialise logging on a Flask app"""
+    handler = logging.StreamHandler()
+    log_format = '%(levelname)s %(message)s'
+
+    if 'WERKZEUG_SERVER_FD' in os.environ:
+        # Use human readable log formatter when using the Werkzeug dev server
+        formatter = logging.Formatter(log_format)
+    else:
+        formatter = JSONFormatter(
+            log_format,
+            ts_log_type='flask',
+            ts_service=app.config.get('TS_SERVICE_NAME', 'unknown'))
+
+    handler.setFormatter(formatter)
+    handler.addFilter(FlaskRequestIdFilter())
+
+    root_logger = logging.getLogger()
+    del root_logger.handlers[:]
+    root_logger.addHandler(handler)
+
+    del app.logger.handlers[:]
+    app.logger.addHandler(handler)
+    app.logger.setLevel(logging.DEBUG if app.debug else logging.INFO)
+
+    init_after_request(app)
+
+
+def init_after_request(app: Flask):
+    """Initialise logging after request handler on a Flask app
+
+    This handler adds a Flask access log
+    """
+
+    @app.after_request
+    def after_request(response):
+        level = _get_level(response)
+        extra = {
+            'method': request.method,
+            'url': request.url,
+            'status': response.status_code,
+        }
+        app.logger.log(
+            level,
+            '{method} {url} {status}'.format(**extra),
+            extra=extra,
+        )
+        response.headers['TS-Request-ID'] = get_flask_request_id()
+
+        return response
+
+
+def _get_level(response):
+    """Get logging level from a Flask response"""
+    return logging.ERROR if response.status_code // 100 == 5 else logging.INFO
+
+
+class FlaskRequestIdFilter(logging.Filter):
+    def filter(self, record):
+        record.request_id = get_flask_request_id()
+
+        return record
+
+
+class FlaskJSONFormatter(JSONFormatter):
+    """An all in one logging formatter for Flask
+
+    This combines the JSONFormatter and the FlaskRequestIdFilter for
+    environments where Filters such as ini file config (gunicorn logging
+    relies on this heavily).
+    """
+    flask_request_id_filter = FlaskRequestIdFilter()
+
+    def _add_request_id(self, log_record, record):
+        record = self.flask_request_id_filter.filter(record)
+        return super()._add_request_id(log_record, record)

--- a/thunderstorm_auth/logging/requests.py
+++ b/thunderstorm_auth/logging/requests.py
@@ -1,0 +1,62 @@
+from requests import *  # noqa
+
+from functools import wraps as _wraps
+
+from requests import request as _request
+from requests import head as _head
+from requests import get as _get
+from requests import post as _post
+from requests import put as _put
+from requests import patch as _patch
+from requests import delete as _delete
+from requests import options as _options
+
+from thunderstorm_auth.logging import get_request_id as _get_request_id
+
+
+@_wraps(_request)
+def request(method, url, **kwargs):
+    return _request(method, url, **_add_request_id(kwargs))
+
+
+@_wraps(_head)
+def head(url, **kwargs):
+    return _head(url, **_add_request_id(kwargs))
+
+
+@_wraps(_get)
+def get(url, **kwargs):
+    return _get(url, **_add_request_id(kwargs))
+
+
+@_wraps(_post)
+def post(url, **kwargs):
+    return _post(url, **_add_request_id(kwargs))
+
+
+@_wraps(_put)
+def put(url, **kwargs):
+    return _put(url, **_add_request_id(kwargs))
+
+
+@_wraps(_patch)
+def patch(url, **kwargs):
+    return _patch(url, **_add_request_id(kwargs))
+
+
+@_wraps(_delete)
+def delete(url, **kwargs):
+    return _delete(url, **_add_request_id(kwargs))
+
+
+@_wraps(_options)
+def options(url, **kwargs):
+    return _options(url, **_add_request_id(kwargs))
+
+
+def _add_request_id(kwargs):
+    headers = kwargs.get('headers', {})
+    headers.setdefault('TS-Request-ID', _get_request_id())
+    kwargs['headers'] = headers
+
+    return kwargs


### PR DESCRIPTION
## Add JSON logging with request IDs

Logs are output as JSON from Celery and Flask.
Request ID is added by Flask and forwarded to Celery tasks.
All logs include the following records if they can:
name, levelname, pathname, lineno, service, log_type, request_id

## add request-id requests wrapper

Add a module that wraps requests and adds the TS-Request-ID header to
each call. This ensures request IDs are propagated across service calls.