### PR TITLE
[feature] consume auth groups from ts.messaging

### DIFF
--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -37,7 +37,7 @@ def celery_app(group_types):
 
 
 def test_exchange_name():
-    assert setup.EXCHANGE.name == 'ts_auth.group'
+    assert setup.EXCHANGE.name == 'ts.messaging'
 
 
 def test_init_group_sync_tasks(celery_app, models, group_types):


### PR DESCRIPTION
This change adds the `ts.messaging` exchange as an additional source for the auth groups. Once this change is rolled out the user service can be updated to send auth group messages to the `ts.messaging` exchange without dropping messages.

This may require a major version bump, @alexanderson and I haven't quite decided yet.