### PR TITLE
Allow sqlalchemy 1.2.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ cryptography>=2.0.3,<3
 pyjwt>=1.5.2,<2
 python-json-logger==0.1.8
 requests==2.18.4
-sqlalchemy>=1.1,<1.2
+sqlalchemy>=1.1,<1.3

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.2.3'
+__version__ = '0.3.0'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'


### PR DESCRIPTION
Specifically needed for multi-table deletes so that we can delete dnqualifiers by complex UUID (through device) in the complex service.

http://docs.sqlalchemy.org/en/latest/core/tutorial.html#multiple-table-deletes

