### PR TITLE
Fix/legacy celery binding

### DIFF
--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -70,5 +70,7 @@ def test_init_group_sync_queue(celery_app, models, group_types):
         for binding in queue.bindings
     } == {
         (setup.EXCHANGE, foo_type.routing_key),
-        (setup.EXCHANGE, bar_type.routing_key)
+        (setup.EXCHANGE, bar_type.routing_key),
+        (setup.LEGACY_EXCHANGE, foo_type.routing_key),
+        (setup.LEGACY_EXCHANGE, bar_type.routing_key),
     }

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'

--- a/thunderstorm_auth/setup.py
+++ b/thunderstorm_auth/setup.py
@@ -95,17 +95,17 @@ def _register_sync_tasks(celery_app, db_session, group_models):
 
 
 def _routing_keys(group_models):
-    return (
+    return [
         group_model.__ts_group_type__.routing_key
         for group_model in group_models
-    )
+    ]
 
 
 def _bindings(exchange, routing_keys):
-    return (
+    return [
         kombu.binding(exchange, routing_key=routing_key)
         for routing_key in routing_keys
-    )
+    ]
 
 
 @signals.worker_ready.connect


### PR DESCRIPTION
props to @shipperizer for finding this out. Because `_routing_keys` is an iterator the `LEGACY_EXCHANGE` never gets bound because the iterator is drained.