### PR TITLE
[TSA-576] authenticated client for managing tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ venv/
 
 .coverage
 coverage.xml
-results.xml
+results*.xml
 /htmlcov/
 
 build/

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 import functools
 
 import jwt.algorithms
@@ -72,7 +72,8 @@ def make_token(private_key, key_id):
         calling the returned object. If no lifetime is specified it defaults
         to 15 minutes.
     """
-    return functools.partial(utils.encode_token,
+    return functools.partial(
+        utils.encode_token,
         private_key,
         key_id
     )
@@ -123,7 +124,7 @@ def refresh_token(make_token, refresh_token_payload):
 @pytest.fixture
 def token_signed_with_incorrect_key(
     key_id, access_token_payload, alternate_private_key
-    ):
+):
     """ Return a token signed with a key that does not match the KID specified
     """
     return utils.encode_token(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import functools
 
 import jwt.algorithms
 import pytest
@@ -47,101 +48,103 @@ def jwk_set(jwk, key_id, alternate_jwk, alternate_key_id):
 
 
 @pytest.fixture
-def token_data():
+def access_token_payload():
     return {
         'username': 'test-user',
-        'permissions': {},
-        'groups': []
+        'token_type': 'access',
+        'groups': [],
+        'permissions': {}
     }
 
 
 @pytest.fixture
-def valid_token(private_key, key_id, token_data):
-    return utils.encode_token(
+def refresh_token_payload():
+    return {
+        'username': 'test-user',
+        'token_type': 'refresh',
+    }
+
+
+@pytest.fixture
+def make_token(private_key, key_id):
+    """Returns a partial object for creating a token.
+        Callers can then specify their desired payload or lifetime when
+        calling the returned object. If no lifetime is specified it defaults
+        to 15 minutes.
+    """
+    return functools.partial(utils.encode_token,
         private_key,
-        key_id,
-        token_data
+        key_id
     )
 
 
 @pytest.fixture
-def valid_token_signed_with_incorrect_key(key_id, token_data, alternate_private_key):
+def access_token(make_token, access_token_payload):
+    return make_token(access_token_payload)
+
+
+@pytest.fixture
+def access_token_with_permissions(make_token, access_token_payload):
+    access_token_payload['permissions'] = {
+        # service name needs to match the service name defined in flask_app fixture
+        'test-service': ['perm-a']
+    }
+    return make_token(access_token_payload)
+
+
+@pytest.fixture
+def access_token_with_permissions_wrong_service(make_token, access_token_payload):
+    access_token_payload['permissions'] = {
+        'other-service': ['perm-a']
+    }
+    return make_token(access_token_payload)
+
+
+@pytest.fixture
+def access_token_expired(make_token, access_token_payload):
+    lifetime = timedelta(hours=-1)
+    return make_token(access_token_payload, lifetime=lifetime)
+
+
+@pytest.fixture
+def access_token_expired_with_permissions(make_token, access_token_payload):
+    lifetime = timedelta(hours=-1)
+    access_token_payload['permissions'] = {
+        'test-service': ['perm-a']
+    }
+    return make_token(access_token_payload, lifetime=lifetime)
+
+
+@pytest.fixture
+def refresh_token(make_token, refresh_token_payload):
+    return make_token(refresh_token_payload)
+
+
+@pytest.fixture
+def token_signed_with_incorrect_key(
+    key_id, access_token_payload, alternate_private_key
+    ):
+    """ Return a token signed with a key that does not match the KID specified
+    """
     return utils.encode_token(
         # token should have been signed with private_key
         alternate_private_key,
         key_id,
-        token_data
+        access_token_payload
     )
 
 
 @pytest.fixture
-def valid_token_with_perm(private_key, key_id, token_data):
-    return utils.encode_token(
-        private_key,
-        key_id,
-        {
-            'username': 'test-user',
-            'permissions': {
-                'test-service': ['perm-a']
-            },
-            'groups': []
-        }
-    )
-
-
-@pytest.fixture
-def valid_token_with_perm_wrong_service(private_key, key_id):
-    return utils.encode_token(
-        private_key,
-        key_id,
-        {
-            'username': 'test-user',
-            'permissions': {
-                'other-service': ['perm-a']
-            },
-            'groups': []
-        }
-    )
-
-
-@pytest.fixture
-def invalid_token():
+def malformed_token():
     # using a junk string here rather than a truncated token as truncated
     # tokens do not trigger the desired error
-    return 'this is not even a token'.encode('utf-8')
+    return 'this is not even a token'
 
 
 @pytest.fixture
-def invalid_token_no_headers(private_key):
+def token_with_no_headers(private_key):
     return jwt.encode(
         {'data': 'nodata'},
         private_key,
         algorithm='RS512'
-    )
-
-
-@pytest.fixture
-def expired_token(private_key, key_id, token_data):
-    expiry = datetime.utcnow() - timedelta(hours=1)
-    return utils.encode_token(
-        private_key,
-        key_id,
-        dict(token_data, exp=expiry)
-    )
-
-
-@pytest.fixture
-def expired_token_with_perm(private_key, key_id):
-    expiry = datetime.utcnow() - timedelta(hours=1)
-    return utils.encode_token(
-        private_key,
-        key_id,
-        {
-            'username': 'test-user',
-            'permissions': {
-                'test-service': ['perm-a']
-            },
-            'groups': [],
-            'exp': expiry,
-        }
     )

--- a/test/falcon/test_falcon_middleware.py
+++ b/test/falcon/test_falcon_middleware.py
@@ -10,7 +10,7 @@ def test_endpoint_returns_200_when_auth_not_required(client, resource):
 
 
 def test_user_with_decoded_token_data_added_to_req_context(
-    falcon_app, client, valid_token_with_perm
+    falcon_app, client, access_token_with_permissions
 ):
     class AssertUserResource:
 
@@ -26,31 +26,33 @@ def test_user_with_decoded_token_data_added_to_req_context(
 
     falcon_app.add_route('/assert-user', AssertUserResource())
 
-    headers = {'X-Thunderstorm-Key': valid_token_with_perm.decode()}
+    headers = {'X-Thunderstorm-Key': access_token_with_permissions}
 
     response = client.simulate_get('/assert-user', headers=headers)
 
     assert response.status_code == 200, response.json
 
 
-def test_endpoint_returns_200_with_proper_token(client, valid_token_with_perm):
-    headers = {'X-Thunderstorm-Key': valid_token_with_perm.decode()}
+def test_endpoint_returns_200_with_proper_token(
+    client, access_token_with_permissions
+):
+    headers = {'X-Thunderstorm-Key': access_token_with_permissions}
 
     response = client.simulate_get('/', headers=headers)
 
     assert response.status_code == 200, response.json
 
 
-def test_endpoint_returns_401_with_invalid_token(client, invalid_token):
-    headers = {'X-Thunderstorm-Key': invalid_token.decode()}
+def test_endpoint_returns_401_with_malformed_token(client, malformed_token):
+    headers = {'X-Thunderstorm-Key': malformed_token}
 
     response = client.simulate_get('/', headers=headers)
 
     assert response.status_code == 401, response.json
 
 
-def test_endpoint_returns_401_with_expired_token(client, expired_token):
-    headers = {'X-Thunderstorm-Key': expired_token.decode()}
+def test_endpoint_returns_401_with_expired_token(client, access_token_expired):
+    headers = {'X-Thunderstorm-Key': access_token_expired}
 
     response = client.simulate_get('/', headers=headers)
 
@@ -58,18 +60,20 @@ def test_endpoint_returns_401_with_expired_token(client, expired_token):
 
 
 def test_endpoint_returns_200_when_expired_token_falls_within_leeway(
-    client, middleware, expired_token_with_perm
+    client, middleware, access_token_expired_with_permissions
 ):
     middleware.expiration_leeway = 3601
-    headers = {'X-Thunderstorm-Key': expired_token_with_perm.decode()}
+    headers = {
+        'X-Thunderstorm-Key': access_token_expired_with_permissions
+    }
 
     response = client.simulate_get('/', headers=headers)
 
     assert response.status_code == 200, response.json
 
 
-def test_endpoint_returns_401_with_no_permissions(client, valid_token):
-    headers = {'X-Thunderstorm-Key': valid_token.decode()}
+def test_endpoint_returns_401_with_no_permissions(client, access_token):
+    headers = {'X-Thunderstorm-Key': access_token}
 
     response = client.simulate_get('/', headers=headers)
 
@@ -77,10 +81,10 @@ def test_endpoint_returns_401_with_no_permissions(client, valid_token):
 
 
 def test_endpoint_returns_401_with_permission_on_wrong_service(
-    client, valid_token_with_perm_wrong_service
+    client, access_token_with_permissions_wrong_service
 ):
-    token = valid_token_with_perm_wrong_service
-    headers = {'X-Thunderstorm-Key': token.decode()}
+    token = access_token_with_permissions_wrong_service
+    headers = {'X-Thunderstorm-Key': token}
 
     response = client.simulate_get('/', headers=headers)
 

--- a/test/flask/test_flask.py
+++ b/test/flask/test_flask.py
@@ -3,7 +3,6 @@ import pytest
 
 from thunderstorm_auth.exceptions import ThunderstormAuthError
 from thunderstorm_auth.flask import ts_auth_required
-from thunderstorm_auth import utils
 
 
 @pytest.fixture

--- a/test/flask/test_flask.py
+++ b/test/flask/test_flask.py
@@ -35,40 +35,42 @@ def test_ts_auth_required_fails_with_non_callable():
         ts_auth_required('my-perm')
 
 
-def test_ts_auth_required_when_bare(valid_token, flask_app):
-    headers = {'X-Thunderstorm-Key': valid_token}
+def test_ts_auth_required_when_bare(access_token, flask_app):
+    headers = {'X-Thunderstorm-Key': access_token}
     response = flask_app.test_client().get('/', headers=headers)
 
     assert response.status_code == 200
 
 
-def test_ts_auth_required_with_no_parameters(valid_token, flask_app):
-    headers = {'X-Thunderstorm-Key': valid_token}
+def test_ts_auth_required_with_no_parameters(access_token, flask_app):
+    headers = {'X-Thunderstorm-Key': access_token}
     response = flask_app.test_client().get('/no-params', headers=headers)
 
     assert response.status_code == 200
 
 
-def test_ts_auth_required_with_permission_no_perm(valid_token, flask_app):
-    headers = {'X-Thunderstorm-Key': valid_token}
+def test_ts_auth_required_with_permission_no_perm(access_token, flask_app):
+    headers = {'X-Thunderstorm-Key': access_token}
     response = flask_app.test_client().get('/perm-a', headers=headers)
 
     assert response.status_code == 403
 
 
 def test_ts_auth_required_with_permission_with_perm(
-    valid_token_with_perm, flask_app
+    access_token_with_permissions, flask_app
 ):
-    headers = {'X-Thunderstorm-Key': valid_token_with_perm}
+    headers = {'X-Thunderstorm-Key': access_token_with_permissions}
     response = flask_app.test_client().get('/perm-a', headers=headers)
 
     assert response.status_code == 200
 
 
 def test_ts_auth_required_with_permission_with_perm_wrong_service(
-    valid_token_with_perm_wrong_service, flask_app
+    access_token_with_permissions_wrong_service, flask_app
 ):
-    headers = {'X-Thunderstorm-Key': valid_token_with_perm_wrong_service}
+    headers = {
+        'X-Thunderstorm-Key': access_token_with_permissions_wrong_service
+    }
     response = flask_app.test_client().get('/perm-a', headers=headers)
 
     assert response.status_code == 403

--- a/test/flask/test_flask_extension.py
+++ b/test/flask/test_flask_extension.py
@@ -3,16 +3,16 @@ from flask import g
 from thunderstorm_auth.user import User
 
 
-def test_endpoint_returns_200_with_proper_token(valid_token, flask_app):
-    headers = {'X-Thunderstorm-Key': valid_token}
+def test_endpoint_returns_200_with_proper_token(access_token, flask_app):
+    headers = {'X-Thunderstorm-Key': access_token}
     response = flask_app.test_client().get('/', headers=headers)
 
     assert response.status_code == 200
 
 
-def test_user_with_decoded_token_added_to_g(valid_token, flask_app):
+def test_user_with_decoded_token_added_to_g(access_token, flask_app):
     with flask_app.app_context():
-        headers = {'X-Thunderstorm-Key': valid_token}
+        headers = {'X-Thunderstorm-Key': access_token}
         flask_app.test_client().get('/', headers=headers)
 
         assert g.user == User(
@@ -22,25 +22,27 @@ def test_user_with_decoded_token_added_to_g(valid_token, flask_app):
         )
 
 
-def test_endpoint_returns_401_with_invalid_token(invalid_token, flask_app):
-    headers = {'X-Thunderstorm-Key': invalid_token}
+def test_endpoint_returns_401_with_malformed_token(malformed_token, flask_app):
+    headers = {'X-Thunderstorm-Key': malformed_token}
     response = flask_app.test_client().get('/', headers=headers)
 
     assert response.status_code == 401
 
 
-def test_endpoint_returns_401_with_expired_token(expired_token, flask_app):
-    headers = {'X-Thunderstorm-Key': expired_token}
+def test_endpoint_returns_401_with_expired_token(
+    access_token_expired, flask_app
+):
+    headers = {'X-Thunderstorm-Key': access_token_expired}
     response = flask_app.test_client().get('/', headers=headers)
 
     assert response.status_code == 401
 
 
 def test_endpoint_returns_200_when_expired_token_falls_within_leeway(
-        flask_app, expired_token):
+        flask_app, access_token_expired):
     with flask_app.app_context():
         flask_app.config['TS_AUTH_LEEWAY'] = 3601
-        headers = {'X-Thunderstorm-Key': expired_token}
+        headers = {'X-Thunderstorm-Key': access_token_expired}
 
         response = flask_app.test_client().get('/', headers=headers)
 
@@ -53,10 +55,10 @@ def test_endpoint_returns_401_with_missing_token(flask_app):
     assert response.status_code == 401
 
 
-def test_endpoint_returns_500_if_no_public_key_set(valid_token, flask_app):
+def test_endpoint_returns_500_if_no_public_key_set(access_token, flask_app):
     with flask_app.app_context():
         flask_app.config['TS_AUTH_JWKS'] = None
-        headers = {'X-Thunderstorm-Key': valid_token}
+        headers = {'X-Thunderstorm-Key': access_token}
 
         response = flask_app.test_client().get('/', headers=headers)
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, PropertyMock
 
 import pytest
 from requests import RequestException
@@ -154,7 +154,7 @@ def test_get_token_expiry_with_expired_token(access_token_expired, jwk_set):
     RequestException
 ])
 def test_assumed_identity_client_refresh_access_token_failure(
-     exception_class, jwk_set, access_token_expired, refresh_token
+    exception_class, jwk_set, access_token_expired, refresh_token
 ):
     # arrange
     client = Client.direct(
@@ -174,7 +174,7 @@ def test_assumed_identity_client_refresh_access_token_failure(
 
 @patch('thunderstorm_auth.client.requests')
 def test_assumed_identity_client_refresh_access_token_success(
-     mock_requests, jwk_set, access_token, refresh_token, access_token_expired
+    mock_requests, jwk_set, access_token, refresh_token, access_token_expired
 ):
     # arrange
     mock_requests.post.return_value.json.return_value = {'token': access_token}

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,0 +1,269 @@
+from unittest.mock import patch, MagicMock, PropertyMock
+
+import pytest
+from requests import RequestException
+
+from thunderstorm_auth.client import (
+    Client, AssumedIdentityAuthenticator, DirectIdentityAuthenticator,
+    get_token_expiry, AssumeIdentityError, RefreshError
+)
+from thunderstorm_auth.decoder import decode_token
+from thunderstorm_auth.exceptions import ThunderstormAuthError
+
+
+def test_direct_returns_client_with_DirectIdentityAuthenticator(
+    jwk_set, access_token, refresh_token
+):
+    # act
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token
+    )
+
+    # assert
+    assert isinstance(client.authenticator, DirectIdentityAuthenticator)
+
+
+def test_assume_identity_returns_client_with_AssumedIdentityAuthenticator(
+    jwk_set, access_token, refresh_token
+):
+    # arrange/act
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token
+    )
+    end_user_client = client.assume_identity(access_token)
+
+    # assert
+    assert isinstance(end_user_client.authenticator, AssumedIdentityAuthenticator)
+
+
+@patch('thunderstorm_auth.client.requests')
+def test_direct_identity_client_requests_access_token_when_none_set(
+    mock_requests, jwk_set, access_token, refresh_token
+):
+    # arrange
+    mock_requests.post.return_value.json.return_value = {'token': access_token}
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token
+    )
+
+    # act
+    client.get('http://example.com')
+
+    # assert
+    mock_requests.post.assert_called_with(
+        'http://user-service-url/api/v1/auth/login',
+        json={'token': refresh_token}
+    )
+
+    mock_requests.get.assert_called_with(
+        'http://example.com',
+        headers={
+            'X-Thunderstorm-Key': access_token
+        }
+    )
+
+
+@patch('thunderstorm_auth.client.requests')
+def test_direct_identity_client_does_not_request_access_token_when_valid_token_set(
+    mock_requests, jwk_set, access_token, refresh_token
+):
+    # arrange
+    mock_requests.post.return_value.json.return_value = {'token': access_token}
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token, access_token=access_token
+    )
+
+    # act
+    client.get('http://example.com')
+
+    # assert
+    assert not mock_requests.post.called
+    mock_requests.get.assert_called_with(
+        'http://example.com',
+        headers={
+            'X-Thunderstorm-Key': access_token
+        }
+    )
+
+
+@patch('thunderstorm_auth.client.requests')
+def test_assume_identity_client_with_valid_token_set_does_not_request_new_token(
+    mock_requests, jwk_set, access_token, refresh_token
+):
+    # arrange
+    mock_requests.post.return_value.json.return_value = {'token': access_token}
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token
+    )
+    end_user_client = client.assume_identity(access_token)
+
+    # act
+    end_user_client.get('http://example.com')
+
+    # assert
+    assert not mock_requests.post.called
+    mock_requests.get.assert_called_with(
+        'http://example.com',
+        headers={'X-Thunderstorm-Key': access_token})
+
+
+@patch('thunderstorm_auth.client.requests')
+def test_assume_identity_client_with_expired_token_refreshes_token(
+    mock_requests, jwk_set, access_token_expired, access_token, refresh_token
+):
+    # arrange
+    mock_requests.post.return_value.json.return_value = {'token': access_token}
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token
+    )
+    end_user_client = client.assume_identity(access_token_expired)
+
+    # act
+    end_user_client.get('http://example.com')
+
+    # assert
+    assert end_user_client.authenticator.access_token == access_token
+
+    mock_requests.post.assert_called_with(
+        'http://user-service-url/api/v1/auth/assume-identity',
+        json={'token': access_token_expired},
+        headers={'X-Thunderstorm-Key': access_token}
+    )
+
+    mock_requests.get.assert_called_with(
+        'http://example.com',
+        headers={'X-Thunderstorm-Key': access_token}
+    )
+
+
+@patch('thunderstorm_auth.client.decode_token')
+def test_get_token_expiry_with_None(mock_decode_token):
+    assert get_token_expiry(None, {'fake': 'jwks'}) is None
+
+
+def test_get_token_expiry_with_expired_token(access_token_expired, jwk_set):
+    exp = decode_token(
+        access_token_expired, jwk_set, options={'verify_exp': False}
+    )['exp']
+
+    assert get_token_expiry(access_token_expired, jwk_set) == exp
+
+
+@pytest.mark.parametrize('exception_class', [
+    ThunderstormAuthError,
+    RequestException
+])
+def test_assumed_identity_client_refresh_access_token_failure(
+     exception_class, jwk_set, access_token_expired, refresh_token
+):
+    # arrange
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token
+    )
+
+    end_user_client = client.assume_identity(access_token_expired)
+
+    # act/assert
+    with patch.object(end_user_client.authenticator._client, '_request', new_callable=PropertyMock) as mock__client:
+        mock__client.post.side_effect = exception_class
+        with pytest.raises(AssumeIdentityError):
+            end_user_client.get('http://foo.com')
+            # not updated
+            assert end_user_client.authenticator.access_token == access_token_expired
+
+
+@patch('thunderstorm_auth.client.requests')
+def test_assumed_identity_client_refresh_access_token_success(
+     mock_requests, jwk_set, access_token, refresh_token, access_token_expired
+):
+    # arrange
+    mock_requests.post.return_value.json.return_value = {'token': access_token}
+    exp = decode_token(access_token, jwk_set)['exp']
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token
+    )
+    end_user_client = client.assume_identity(access_token_expired)
+
+    # act
+    end_user_client.authenticator.refresh_access_token()
+
+    # assert
+    assert end_user_client.authenticator.access_token is access_token
+    assert end_user_client.authenticator._access_token_expiry == exp
+
+
+@patch('thunderstorm_auth.client.requests')
+def test_direct_identity_client_refresh_access_token_success(
+    mock_requests, jwk_set, access_token_expired, refresh_token, access_token
+):
+    # arrange
+    mock_requests.post.return_value.json.return_value = {'token': access_token}
+    exp = decode_token(
+        access_token,
+        jwk_set,
+        options={'verify_exp': False}
+    )['exp']
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token, access_token=access_token_expired
+    )
+
+    # act
+    client.authenticator.refresh_access_token()
+
+    # assert
+    assert client.authenticator.access_token == access_token
+    assert client.authenticator._access_token_expiry == exp
+
+
+@patch('thunderstorm_auth.client.requests')
+def test_direct_identity_client_refresh_access_token_failure(
+    mock_requests, jwk_set, access_token_expired, refresh_token, access_token
+):
+    # arrange
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token, access_token=access_token_expired
+    )
+    exp = decode_token(
+        access_token_expired,
+        jwk_set,
+        options={'verify_exp': False}
+    )['exp']
+
+    # because we patch requests we need to put back RequestException otherwise
+    # the except block of refresh_access_token will fail
+    mock_requests.RequestException = RequestException
+    mock_requests.post.side_effect = ThunderstormAuthError
+
+    # act/assert
+    # act/assert
+    with pytest.raises(RefreshError):
+        client.get('http://foo.com')
+        # not updated
+        assert client.authenticator.access_token == access_token_expired
+        assert client.authenticator._access_token_expiry == exp
+
+
+@pytest.mark.parametrize('http_method', [
+    'get',
+    'post',
+    'put',
+    'patch',
+    'options',
+    'delete'
+])
+def test_client_calls__request_with__correct_args(
+    http_method, access_token, jwk_set, refresh_token
+):
+    # arrange
+    client = Client.direct(
+        'http://user-service-url', jwk_set, refresh_token, access_token=access_token
+    )
+
+    # act
+    with patch.object(client, '_request', new_callable=PropertyMock) as mock__request:
+        getattr(client, http_method)('http://foo.com', 'arg1', 'arg2', kwarg='some_kwarg')
+        mock__request.assert_called_with(
+            http_method,
+            ('http://foo.com', 'arg1', 'arg2'),
+            {'kwarg': 'some_kwarg'}
+        )

--- a/test/test_decoder.py
+++ b/test/test_decoder.py
@@ -5,49 +5,59 @@ from thunderstorm_auth.exceptions import (ExpiredTokenError, BrokenTokenError, M
                                           TokenDecodeError)
 
 
-def test_decode_token_returns_if_jwt_valid(valid_token, jwk_set):
-    assert decode_token(valid_token, jwk_set)
+def test_decode_token_returns_if_jwt_valid(access_token, jwk_set):
+    assert decode_token(access_token, jwk_set)
 
 
-def test_decode_token_raises_if_jwt_invalid(invalid_token, jwk_set):
+def test_decode_token_raises_if_jwt_malformed(malformed_token, jwk_set):
     with pytest.raises(BrokenTokenError):
-        decode_token(invalid_token, jwk_set)
+        decode_token(malformed_token, jwk_set)
 
 
-def test_decode_token_raises_if_jwt_headers_invalid(invalid_token_no_headers, jwk_set):
+def test_decode_token_raises_if_jwt_headers_missing(
+    token_with_no_headers, jwk_set
+):
     with pytest.raises(BrokenTokenError):
-        decode_token(invalid_token_no_headers, jwk_set)
+        decode_token(token_with_no_headers, jwk_set)
 
 
-def test_decode_token_raises_if_jwt_expired(expired_token, jwk_set):
+def test_decode_token_raises_if_jwt_expired(access_token_expired, jwk_set):
     with pytest.raises(ExpiredTokenError):
-        decode_token(expired_token, jwk_set)
+        decode_token(access_token_expired, jwk_set)
 
 
 def test_decode_token_does_not_raise_if_jwt_expired_but_verify_exp_false(
-    expired_token, jwk_set
+    access_token_expired, jwk_set
 ):
-    assert decode_token(expired_token, jwk_set, options={'verify_exp': False})
+    assert decode_token(
+        access_token_expired,
+        jwk_set,
+        options={'verify_exp': False}
+    )
 
 
 def test_decode_token_does_not_raise_if_jwt_expired_but_leeway_is_set(
-        expired_token, jwk_set):
-    assert decode_token(expired_token, jwk_set, leeway=3605)
+        access_token_expired, jwk_set):
+    assert decode_token(access_token_expired, jwk_set, leeway=3605)
 
 
 def test_decode_token_with_jwk_set_raises_broken_token_error_if_token_is_malformed(
-        invalid_token, jwk_set):
+        malformed_token, jwk_set):
     with pytest.raises(BrokenTokenError):
-        decode_token(invalid_token, jwk_set, leeway=3605)
+        decode_token(malformed_token, jwk_set, leeway=3605)
 
 
-def test_decode_token_raises_missing_key_error_if_invalid_key_id_specified_in_jwk(valid_token):
+def test_decode_token_raises_missing_key_error_if_invalid_key_id_specified_in_jwk(
+    access_token
+):
     with pytest.raises(MissingKeyErrror):
-        decode_token(valid_token, {})
+        decode_token(access_token, {})
 
 
-def test_get_headers_from_token_returns_key_id_and_signing_algorithm(valid_token, key_id):
-    kid, alg = get_kid_and_alg_headers_from_token(valid_token)
+def test_get_headers_from_token_returns_key_id_and_signing_algorithm(
+    access_token, key_id
+):
+    kid, alg = get_kid_and_alg_headers_from_token(access_token)
     assert kid == key_id
     assert alg == 'RS512'
 
@@ -57,6 +67,6 @@ def test_get_headers_from_token_raises_BrokenTokenError_if_headers_are_missing()
         get_kid_and_alg_headers_from_token('not a token')
 
 
-def test_decode_valid_token_with_invalid_key(valid_token_signed_with_incorrect_key, jwk_set):
+def test_decode_valid_token_with_invalid_key(token_signed_with_incorrect_key, jwk_set):
     with pytest.raises(TokenDecodeError):
-        decode_token(valid_token_signed_with_incorrect_key, jwk_set)
+        decode_token(token_signed_with_incorrect_key, jwk_set)

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.3.5'
+__version__ = '0.3.6'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'

--- a/thunderstorm_auth/client.py
+++ b/thunderstorm_auth/client.py
@@ -159,7 +159,7 @@ class Client:
         headers = kwargs.setdefault('headers', {})
         headers[TOKEN_HEADER] = self.authenticator.access_token
 
-        res = requests.get(*args, **kwargs)
+        res = getattr(requests, method)(*args, **kwargs)
 
         if res.status_code == 401 and refresh:
             self.authenticator.refresh_access_token()

--- a/thunderstorm_auth/client.py
+++ b/thunderstorm_auth/client.py
@@ -1,0 +1,183 @@
+from datetime import datetime
+from abc import ABCMeta, abstractmethod
+
+import requests
+
+from thunderstorm_auth import TOKEN_HEADER
+from thunderstorm_auth.decoder import decode_token
+from thunderstorm_auth.exceptions import ThunderstormAuthError
+
+
+class RefreshError(Exception):
+    def __init__(self, error):
+        self.error = error
+
+
+class AssumeIdentityError(Exception):
+    def __init__(self, error):
+        self.error = error
+
+
+class Authenticator(metaclass=ABCMeta):
+    """Abstract base class for managing auth refresh cycles"""
+
+    def __init__(self):
+        self._cached_access_token_expiry = None
+
+    @property
+    @abstractmethod
+    def access_token(self):
+        pass
+
+    def needs_refresh(self):
+        if not self.access_token:
+            return True
+        if _is_time_in_past(self._cached_access_token_expiry):
+            return True
+        return False
+
+    @abstractmethod
+    def refresh_access_token(self):
+        pass
+
+    def _parse_response(self, resp):
+        resp.raise_for_status()
+        access_token = resp.json()['token']
+        payload = decode_token(access_token, self.jwks)
+
+        return (access_token, payload)
+
+
+class DirectIdentityAuthenticator(Authenticator):
+    """Manages the token refresh cycle for normal authentication"""
+
+    def __init__(self, user_service_url, jwks, access_token, refresh_token):
+        super()
+        self.user_service_url = user_service_url
+        self.jwks = jwks
+        self._access_token = access_token
+        self._refresh_token = refresh_token
+
+    @property
+    def access_token(self):
+        return self._access_token
+
+    def refresh_access_token(self):
+        try:
+            resp = requests.post(
+                '{}/api/v1/auth/login'.format(self.user_serivce_url),
+                json={'token': self.refresh_token},
+            )
+            access_token, payload = self._parse_response(resp)
+        except (requests.RequestException, ThunderstormAuthError) as err:
+            raise RefreshError(err)
+        else:
+            self._access_token = access_token
+            self._cached_access_token_expiry = payload['exp']
+
+
+class AssumedIdentityAuthenticator(Authenticator):
+    """Manages the token refresh cycle for assumed identity authentication"""
+
+    def __init__(self, client, assume_identity):
+        super()
+        self.client = client
+        self._assumed_identity_access_token = assume_identity
+
+    @property
+    def access_token(self):
+        return self._assumed_identity_access_token
+
+    def refresh_access_token(self):
+        try:
+            resp = self._client.post(
+                '{}/api/v1/auth/assume-identity'.format(
+                    self.client.user_serivce_url
+                ),
+                json={'token': self._assumed_identity_access_token},
+            )
+            access_token, payload = self._parse_response(resp)
+        except (requests.RequestException, ThunderstormAuthError) as err:
+            raise AssumeIdentityError(err)
+        else:
+            self._assumed_identity_access_token = access_token
+            self._cached_access_token_expiry = payload['exp']
+
+
+class Client:
+    """Authenticated AAM HTTP client
+
+    This client presents a requests interface that automatically adds and
+    refreshes thunderstorm authentication details.
+
+    It can also be used to assume an end user identity and make requests
+    as that identity.
+
+    Usage:
+        >>> client = Client.direct(
+        ...     user_service_url, jwks, access_token, refresh_token
+        ... )
+        >>> client.get(some_url)
+        >>> end_user_client = client.assume_identity(end_user_access_token)
+        >>> end_user_client.get(some_url)
+    """
+    def __init__(self, authenticator: Authenticator):
+        self.authenticator = authenticator
+
+    @staticmethod
+    def direct(user_service_url, jwks, access_token, refresh_token):
+        return Client(
+            DirectIdentityAuthenticator(
+                user_service_url, jwks, access_token, refresh_token
+            )
+        )
+
+    def assume_identity(self, assume_identity):
+        return Client(AssumedIdentityAuthenticator(self, assume_identity))
+
+    def get(self, *args, **kwargs):
+        return self._request('GET', args, kwargs)
+
+    def post(self, *args, **kwargs):
+        return self._request('POST', args, kwargs)
+
+    def put(self, *args, **kwargs):
+        return self._request('PUT', args, kwargs)
+
+    def patch(self, *args, **kwargs):
+        return self._request('PATCH', args, kwargs)
+
+    def options(self, *args, **kwargs):
+        return self._request('OPTIONS', args, kwargs)
+
+    def _request(self, method, args, kwargs, *, refresh=True):
+        """Make an authenticated request refreshing if needed"""
+        if refresh and self.authenticator.needs_refresh():
+            self.authenticator.refresh_access_token()
+            refresh = False
+
+        headers = kwargs.setdefault('headers', {})
+        headers[TOKEN_HEADER] = self.authenticator.access_token
+
+        res = requests.get(*args, **kwargs)
+
+        if res.status_code == 401 and refresh:
+            self.authenticator.refresh_access_token()
+            return self._request(method, args, kwargs, refresh=False)
+
+
+def _is_time_in_past(stamp):
+    """Return True if the provided timestamp is in the past
+
+    Args:
+        stamp (datetime): Timestamp to test
+
+    Return:
+        boolean
+    """
+    if stamp is None:
+        return True
+    elif stamp < datetime.utcnow():
+        return True
+
+    return False

--- a/thunderstorm_auth/utils.py
+++ b/thunderstorm_auth/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import hashlib
 import json
 
@@ -37,7 +38,7 @@ def generate_key_id(jwk):
     ).hexdigest()
 
 
-def encode_token(private_key, key_id, payload):
+def encode_token(private_key, key_id, payload, lifetime=None):
     """Encode a token with a private key
 
     Args:
@@ -48,9 +49,19 @@ def encode_token(private_key, key_id, payload):
     Returns:
         str: Encoded JWT
     """
+    # issued at time
+    payload['iat'] = datetime.utcnow()
+
+    lifetime = lifetime or timedelta(minutes=15)
+
+    expiry = datetime.utcnow() + lifetime
+    payload['exp'] = expiry
+
     return jwt.encode(
         payload,
         private_key,
         algorithm='RS512',
-        headers={'kid': key_id}
-    )
+        headers={
+            'kid': key_id
+        }
+    ).decode()


### PR DESCRIPTION
This client shows how we might implement an authenticated API client that automatically handles refreshing the access token. It also provides an interface for assuming an end user's identity and refreshing that token as well.

The `DirectIdentityAuthenticator` uses the API user's credentials and uses that to refresh that auth token when it expires.

The `AssumedIdentityAuthenticator` instead makes an authenticated request against the new `/api/v1/auth/assume-identity` endpoint. In order to handle token expiry on the API user's credentials this authenticated request is made through the provided client which in turn is authenticated with the `DirectIdentityAuthenticator`.

In the worst case there are two requests to the user service in order to service a single API request.