### PR TITLE
tsa-561 log an error on auth with no permission

### DIFF
--- a/thunderstorm_auth/flask.py
+++ b/thunderstorm_auth/flask.py
@@ -98,6 +98,10 @@ def _validate_permission(token_data, permission):
     if permission:
         service_name = current_app.config['TS_SERVICE_NAME']
         permissions.validate_permission(token_data, service_name, permission)
+    else:
+        current_app.logger.error(
+            'Route with auth but no permission: {}'.format(request.path)
+        )
 
 
 def _bad_token(error):


### PR DESCRIPTION
When a flask endpoint uses the `ts_auth_required` decorator but does not
provide a permission log an error. This is a use case that we no longer
want to support. In future this will cause an error.