### PR TITLE
Add permission support to falcon middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ def init_celery(celery_app):
 
 #### Defining permissions
 
+\[[Falcon](./docs/falcon.md#defining-permissions)\]
+
 Now that we have the permissions model, CLI and syncing fully integrated we
 can start using permissions.
 

--- a/docs/falcon.md
+++ b/docs/falcon.md
@@ -51,12 +51,33 @@ class MyResource:
 
 ### Permissions
 
-Not yet implemented for Falcon
+See \[[Flask docs](/README.md#permissions)\] for managing the Permission model.
 
 #### Defining permissions
 
-Not yet implemented for Falcon
+Now that we have the permissions model, CLI and syncing fully integrated we
+can start using permissions.
+
+To require a specific permission for a given middleware instance add
+the `with_permission` and `service_name` keyword arguments to the
+`TsAuthMiddleware` constructor.
+
+```python
+auth_middleware = TsAuthMiddleware(
+  os.environ['TS_AUTH_JWKS'],
+  with_permission='my-permission',
+  service_name=os.environ['TS_SERVICE_NAME'],
+)
+...
+```
+
+Now a request through this middleware will only be allowed if it has a valid
+authentication token and that token contains the `my-permission` permission
+for the given service. In order for that to be possible the user service needs
+to be made aware of this new permission. See the 
+[Flask docs](/README.md#defining-permissions) managing the Permission model.
 
 #### Deploying permissions
 
+See \[[Flask docs](/README.md#deploying-permissions)\] for managing the Permission model.
 Not yet implemented for Falcon

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -75,6 +75,36 @@ def valid_token_signed_with_incorrect_key(key_id, token_data, alternate_private_
 
 
 @pytest.fixture
+def valid_token_with_perm(private_key, key_id, token_data):
+    return utils.encode_token(
+        private_key,
+        key_id,
+        {
+            'username': 'test-user',
+            'permissions': {
+                'test-service': ['perm-a']
+            },
+            'groups': []
+        }
+    )
+
+
+@pytest.fixture
+def valid_token_with_perm_wrong_service(private_key, key_id):
+    return utils.encode_token(
+        private_key,
+        key_id,
+        {
+            'username': 'test-user',
+            'permissions': {
+                'other-service': ['perm-a']
+            },
+            'groups': []
+        }
+    )
+
+
+@pytest.fixture
 def invalid_token():
     # using a junk string here rather than a truncated token as truncated
     # tokens do not trigger the desired error
@@ -97,4 +127,21 @@ def expired_token(private_key, key_id, token_data):
         private_key,
         key_id,
         dict(token_data, exp=expiry)
+    )
+
+
+@pytest.fixture
+def expired_token_with_perm(private_key, key_id):
+    expiry = datetime.utcnow() - timedelta(hours=1)
+    return utils.encode_token(
+        private_key,
+        key_id,
+        {
+            'username': 'test-user',
+            'permissions': {
+                'test-service': ['perm-a']
+            },
+            'groups': [],
+            'exp': expiry,
+        }
     )

--- a/test/falcon/conftest.py
+++ b/test/falcon/conftest.py
@@ -19,7 +19,11 @@ def resource():
 
 @pytest.fixture
 def middleware(jwk_set):
-    return TsAuthMiddleware(jwk_set)
+    return TsAuthMiddleware(
+        jwk_set,
+        with_permission='perm-a',
+        service_name='test-service',
+    )
 
 
 @pytest.fixture

--- a/test/flask/test_flask.py
+++ b/test/flask/test_flask.py
@@ -7,36 +7,6 @@ from thunderstorm_auth import utils
 
 
 @pytest.fixture
-def valid_token_with_perm(private_key, key_id, token_data):
-    return utils.encode_token(
-        private_key,
-        key_id,
-        {
-            'username': 'test-user',
-            'permissions': {
-                'test-service': ['perm-a']
-            },
-            'groups': []
-        }
-    )
-
-
-@pytest.fixture
-def valid_token_with_perm_wrong_service(private_key, key_id):
-    return utils.encode_token(
-        private_key,
-        key_id,
-        {
-            'username': 'test-user',
-            'permissions': {
-                'other-service': ['perm-a']
-            },
-            'groups': []
-        }
-    )
-
-
-@pytest.fixture
 def flask_app(jwk_set):
     app = flask.Flask('test_app')
     app.config['TS_AUTH_JWKS'] = jwk_set

--- a/thunderstorm_auth/falcon.py
+++ b/thunderstorm_auth/falcon.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import warnings
 
 from thunderstorm_auth import TOKEN_HEADER
 from thunderstorm_auth.decoder import decode_token
@@ -52,6 +53,10 @@ class TsAuthMiddleware:
 
         if not self.with_permission:
             logger.error('Auth configured with no permission')
+            warnings.warn(
+                'Route with auth but no permission. '
+                'In future this will not be allowed.'
+            )
 
     def process_resource(self, req, res, resource, params):
         requires_auth = getattr(resource, 'requires_auth', False)

--- a/thunderstorm_auth/falcon.py
+++ b/thunderstorm_auth/falcon.py
@@ -1,9 +1,13 @@
 import json
+import logging
 
 from thunderstorm_auth import TOKEN_HEADER
 from thunderstorm_auth.decoder import decode_token
-from thunderstorm_auth.exceptions import ThunderstormAuthError
-from thunderstorm_auth.exceptions import TokenError, TokenHeaderMissing, AuthJwksNotSet
+from thunderstorm_auth.exceptions import (
+    TokenError, TokenHeaderMissing, AuthJwksNotSet,
+    ThunderstormAuthError, InsufficientPermissions
+)
+from thunderstorm_auth import permissions
 from thunderstorm_auth.user import User
 
 try:
@@ -13,13 +17,19 @@ except ImportError:
     HAS_FALCON = False
 
 
+logger = logging.getLogger(__name__)
+
 USER_CONTEXT_KEY = 'ts_user'
 
 
 class TsAuthMiddleware:
     """Falcon middleware for Thunderstorm Authentication."""
 
-    def __init__(self, jwks, expiration_leeway=0):
+    def __init__(
+        self, jwks, expiration_leeway=0,
+        with_permission=None, service_name=None,
+
+    ):
         """Falcon middleware for Thunderstorm Authentication.
 
         Args:
@@ -37,6 +47,11 @@ class TsAuthMiddleware:
 
         self.expiration_leeway = expiration_leeway
         self.jwks = jwks
+        self.with_permission = with_permission
+        self.service_name = service_name
+
+        if not self.with_permission:
+            logger.error('Auth configured with no permission')
 
     def process_resource(self, req, res, resource, params):
         requires_auth = getattr(resource, 'requires_auth', False)
@@ -44,7 +59,8 @@ class TsAuthMiddleware:
         if requires_auth:
             try:
                 decoded_token_data = self._decode_token(req)
-            except TokenError as error:
+                self._validate_permission(decoded_token_data)
+            except (TokenError, InsufficientPermissions) as error:
                 raise _bad_token(error)
 
             user = User.from_decoded_token(decoded_token_data)
@@ -61,6 +77,12 @@ class TsAuthMiddleware:
             self.jwks,
             leeway=self.expiration_leeway
         )
+
+    def _validate_permission(self, token_data):
+        if self.with_permission:
+            permissions.validate_permission(
+                token_data, self.service_name, self.with_permission
+            )
 
 
 def _get_token(request):

--- a/thunderstorm_auth/flask.py
+++ b/thunderstorm_auth/flask.py
@@ -1,5 +1,6 @@
 from functools import wraps
 import uuid
+import warnings
 
 from flask import g
 import click
@@ -44,6 +45,11 @@ def ts_auth_required(func=None, *, with_permission=None):
 
     if with_permission is not None:
         permissions.register_permission(with_permission)
+    else:
+        warnings.warn(
+            'Route with auth but no permission. '
+            'In future this will not be allowed.'
+        )
 
     def wrapper(func):
         @wraps(func)


### PR DESCRIPTION
This just adds the ability to validate permissions in the Falcon middleware. It does not implement any of the Permission model management stuff.