### PR TITLE
Add options to decode token

### DIFF
--- a/test/test_decoder.py
+++ b/test/test_decoder.py
@@ -5,37 +5,37 @@ from thunderstorm_auth.exceptions import (ExpiredTokenError, BrokenTokenError, M
                                           TokenDecodeError)
 
 
-def test_get_decoded_token_returns_if_jwt_valid(valid_token, jwk_set):
+def test_decode_token_returns_if_jwt_valid(valid_token, jwk_set):
     assert decode_token(valid_token, jwk_set)
 
 
-def test_get_decoded_token_raises_if_jwt_invalid(invalid_token, jwk_set):
+def test_decode_token_raises_if_jwt_invalid(invalid_token, jwk_set):
     with pytest.raises(BrokenTokenError):
         decode_token(invalid_token, jwk_set)
 
 
-def test_get_decoded_token_raises_if_jwt_headers_invalid(invalid_token_no_headers, jwk_set):
+def test_decode_token_raises_if_jwt_headers_invalid(invalid_token_no_headers, jwk_set):
     with pytest.raises(BrokenTokenError):
         decode_token(invalid_token_no_headers, jwk_set)
 
 
-def test_get_decoded_token_raises_if_jwt_expired(expired_token, jwk_set):
+def test_decode_token_raises_if_jwt_expired(expired_token, jwk_set):
     with pytest.raises(ExpiredTokenError):
         decode_token(expired_token, jwk_set)
 
 
-def test_get_decoded_token_does_not_raise_if_jwt_expired_but_leeway_is_set(
 def test_decode_token_does_not_raise_if_jwt_expired_but_verify_exp_false(
     expired_token, jwk_set
 ):
     assert decode_token(expired_token, jwk_set, options={'verify_exp': False})
 
 
+def test_decode_token_does_not_raise_if_jwt_expired_but_leeway_is_set(
         expired_token, jwk_set):
     assert decode_token(expired_token, jwk_set, leeway=3605)
 
 
-def test_get_decoded_token_with_jwk_set_raises_broken_token_error_if_token_is_malformed(
+def test_decode_token_with_jwk_set_raises_broken_token_error_if_token_is_malformed(
         invalid_token, jwk_set):
     with pytest.raises(BrokenTokenError):
         decode_token(invalid_token, jwk_set, leeway=3605)

--- a/test/test_decoder.py
+++ b/test/test_decoder.py
@@ -25,6 +25,12 @@ def test_get_decoded_token_raises_if_jwt_expired(expired_token, jwk_set):
 
 
 def test_get_decoded_token_does_not_raise_if_jwt_expired_but_leeway_is_set(
+def test_decode_token_does_not_raise_if_jwt_expired_but_verify_exp_false(
+    expired_token, jwk_set
+):
+    assert decode_token(expired_token, jwk_set, options={'verify_exp': False})
+
+
         expired_token, jwk_set):
     assert decode_token(expired_token, jwk_set, leeway=3605)
 

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.3.4'
+__version__ = '0.3.5'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'

--- a/thunderstorm_auth/decoder.py
+++ b/thunderstorm_auth/decoder.py
@@ -8,7 +8,7 @@ from thunderstorm_auth.exceptions import (ExpiredTokenError, BrokenTokenError, M
                                           TokenDecodeError)
 
 
-def decode_token(token, jwks, leeway=DEFAULT_LEEWAY):
+def decode_token(token, jwks, leeway=DEFAULT_LEEWAY, options=None):
     """Decode and extract data from a JWT.
 
     Args:
@@ -16,6 +16,8 @@ def decode_token(token, jwks, leeway=DEFAULT_LEEWAY):
         jwks (dict): JWK Set containing JWKs to be tried to decode the token.
         leeway (int): Number of seconds of lenience used in determining if a
             token has expired.
+        options (dict): Allow the caller to pass additional options to the
+            decode method of pyjwt.
 
     Returns:
          dict payload stored in the token
@@ -34,7 +36,8 @@ def decode_token(token, jwks, leeway=DEFAULT_LEEWAY):
             token,
             key=public_key,
             leeway=leeway,
-            algorithms=[algorithm]
+            algorithms=[algorithm],
+            options=options
         )
 
     except jwt.exceptions.ExpiredSignatureError:


### PR DESCRIPTION
Adding an options kwarg to the decode_token function. These options are then passed to the decode function of pyjwt, thus giving you greater control over how decoding is handled (such as specifying that you do not wish to verify the expiry time of a token when decoding it)