### PR TITLE
Fix http exceptions

### DIFF
--- a/test/flask/conftest.py
+++ b/test/flask/conftest.py
@@ -2,16 +2,34 @@ import flask
 import pytest
 
 from thunderstorm_auth.flask import ts_auth_required
-
+from thunderstorm_auth.exceptions import HTTPError
 
 @pytest.fixture
 def flask_app(jwk_set):
     app = flask.Flask('test_app')
     app.config['TS_AUTH_JWKS'] = jwk_set
 
+    app.config['TS_SERVICE_NAME'] = 'test-service'
+
     @app.route('/')
     @ts_auth_required
     def hello_world():
         return 'Hello, World!'
+
+    @app.route('/no-params')
+    @ts_auth_required()
+    def no_params():
+        return 'no params'
+
+    @app.route('/perm-a')
+    @ts_auth_required(with_permission='perm-a')
+    def with_perm_a():
+        return 'with perm a'
+
+    @app.errorhandler(HTTPError)
+    def handle_invalid_usage(exc):
+        data = {'code': exc.code, 'message': exc.message}
+
+        return flask.jsonify(data), data['code']
 
     return app

--- a/test/flask/test_flask.py
+++ b/test/flask/test_flask.py
@@ -5,30 +5,6 @@ from thunderstorm_auth.exceptions import ThunderstormAuthError
 from thunderstorm_auth.flask import ts_auth_required
 
 
-@pytest.fixture
-def flask_app(jwk_set):
-    app = flask.Flask('test_app')
-    app.config['TS_AUTH_JWKS'] = jwk_set
-    app.config['TS_SERVICE_NAME'] = 'test-service'
-
-    @app.route('/')
-    @ts_auth_required
-    def hello_world():
-        return 'Hello, World!'
-
-    @app.route('/no-params')
-    @ts_auth_required()
-    def no_params():
-        return 'no params'
-
-    @app.route('/perm-a')
-    @ts_auth_required(with_permission='perm-a')
-    def with_perm_a():
-        return 'with perm a'
-
-    return app
-
-
 def test_ts_auth_required_fails_with_non_callable():
     with pytest.raises(ThunderstormAuthError):
         ts_auth_required('my-perm')

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.3.7'
+__version__ = '0.3.8'
 
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'

--- a/thunderstorm_auth/decoder.py
+++ b/thunderstorm_auth/decoder.py
@@ -46,8 +46,8 @@ def decode_token(token, jwks, leeway=DEFAULT_LEEWAY, options=None):
         )
     except jwt.exceptions.DecodeError as ex:
         raise TokenDecodeError('An error occurred while decoding your token: {}'.format(ex))
-    except BrokenTokenError as ex:
-        raise BrokenTokenError(ex)
+    except BrokenTokenError:
+        raise
     except KeyError:
         raise MissingKeyErrror(
             'The key_id specified in your token is not present in the JWK set provided.'

--- a/thunderstorm_auth/exceptions.py
+++ b/thunderstorm_auth/exceptions.py
@@ -39,10 +39,21 @@ class InsufficientPermissions(ThunderstormAuthError):
     pass
 
 
+# TODO: Review in future whether or not this should be pulled from the
+# thunderstorm library. for now try and keep them in sync
 class HTTPError(ThunderstormAuthError):
-    """To be used when raising exceptions to be caught by the flask app
+    """To be used when creating HTTP exceptions to be caught by the flask app
     """
     def __init__(self, message='Error', code=None):
-        super().__init__()
         self.message = message
         self.code = code
+
+
+class Unauthorized(HTTPError):
+    def __init__(self, message='Unauthorized'):
+        super().__init__(message=message, code=401)
+
+
+class Forbidden(HTTPError):
+    def __init__(self, message='Forbidden'):
+        super().__init__(message=message, code=403)

--- a/thunderstorm_auth/exceptions.py
+++ b/thunderstorm_auth/exceptions.py
@@ -37,3 +37,12 @@ class ExpiredTokenError(TokenError):
 
 class InsufficientPermissions(ThunderstormAuthError):
     pass
+
+
+class HTTPError(ThunderstormAuthError):
+    """To be used when raising exceptions to be caught by the flask app
+    """
+    def __init__(self, message='Error', code=None):
+        super().__init__()
+        self.message = message
+        self.code = code

--- a/thunderstorm_auth/permissions.py
+++ b/thunderstorm_auth/permissions.py
@@ -25,11 +25,11 @@ def validate_permission(token_data, service_name, permission):
                                  permission
     """
     if not isinstance(token_data, Mapping):
-        raise BrokenTokenError()
+        raise BrokenTokenError('Token data must be structured as a dict')
     elif not isinstance(token_data.get('permissions'), Mapping):
-        raise BrokenTokenError()
+        raise BrokenTokenError('Token permissions must be structured as a dict')
     elif permission not in token_data['permissions'].get(service_name, []):
-        raise InsufficientPermissions()
+        raise InsufficientPermissions('You do not have the permission required to carry out this action')
 
 
 def register_permission(permission):


### PR DESCRIPTION
Instead of returning response objects from the auth library we should raise exceptions and let the apps using the library decide how to handle them.

This PR:
1. Removes a redundant flask_app fixture
2. Raises exceptions for 401 and 403 status codes rather than returning response objects
3. Updates the flask_app fixture to work with the new exception handling structure
4. Fixes a piece of code that was re-raising an exception in an incorrect manner

https://github.com/artsalliancemedia/thunderstorm-auth-library/issues/52