### PR TITLE
[fix] request_republish_group_task doesn't run on its own anymore

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -215,7 +215,8 @@ def role_setup(fixtures, role_uuid):
 @pytest.fixture
 def role_tasks(db_session):
     datastore = SQLAlchemySessionAuthStore(
-        db_session, models.Role, models.Permission, models.RolePermissionAssociation
+        db_session, models.Role, models.Permission, models.RolePermissionAssociation,
+        models.ComplexGroupComplexAssociation
     )
     # initialize only once the tasks, return a mapping task name: task
     return {t.name: t for t in _init_role_tasks(datastore)}
@@ -223,7 +224,10 @@ def role_tasks(db_session):
 
 @pytest.fixture(scope='function')
 def datastore(db_session):
-    return SQLAlchemySessionAuthStore(db_session, models.Role, models.Permission, models.RolePermissionAssociation)
+    return SQLAlchemySessionAuthStore(
+        db_session, models.Role, models.Permission, models.RolePermissionAssociation,
+        models.ComplexGroupComplexAssociation
+    )
 
 
 @pytest.fixture

--- a/thunderstorm_auth/__init__.py
+++ b/thunderstorm_auth/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'thunderstorm-auth-lib'
-__version__ = '0.7.6'
+__version__ = '0.7.7'
 
 TOKEN_HEADER = 'X-Thunderstorm-Key'
 


### PR DESCRIPTION
@artsalliancemedia/thunderstorm

**## Non backwards compatibilities:**

* the datastore object now needs the group association model to be passed in, this is an effort to move all the group stuff into the datastore

